### PR TITLE
Fix cinder authentication and error handling when enabling exporters

### DIFF
--- a/exporter.go
+++ b/exporter.go
@@ -93,7 +93,9 @@ func NewExporter(name string, prefix string, config *Cloud) (OpenStackExporter, 
 	}
 
 	newClient.SetRequiredServiceTypes([]string{name})
-	newClient.Authenticate()
+	if err := newClient.Authenticate(); err != nil {
+		return nil, fmt.Errorf("error when authenticating: %s", err)
+	}
 
 	switch name {
 	case "network":

--- a/exporter.go
+++ b/exporter.go
@@ -92,6 +92,12 @@ func NewExporter(name string, prefix string, config *Cloud) (OpenStackExporter, 
 		newClient = client.NewClient(&credentials, authMode, nil)
 	}
 
+	// Change service name to the v3 version of cinder/block storage API.
+	// Part of fix for: https://github.com/openstack-exporter/openstack-exporter/issues/1
+	if name == "volume" {
+		name = "volumev3"
+	}
+
 	newClient.SetRequiredServiceTypes([]string{name})
 	if err := newClient.Authenticate(); err != nil {
 		return nil, fmt.Errorf("error when authenticating: %s", err)
@@ -119,7 +125,7 @@ func NewExporter(name string, prefix string, config *Cloud) (OpenStackExporter, 
 				return nil, err
 			}
 		}
-	case "volume":
+	case "volumev3":
 		{
 			exporter, err = NewCinderExporter(newClient, prefix, config)
 			if err != nil {

--- a/main.go
+++ b/main.go
@@ -63,7 +63,9 @@ func main() {
 		if !*disabled {
 			_, err := EnableExporter(service, *prefix, cloudConfig)
 			if err != nil {
-				log.Fatal(err)
+				// Log error and continue with enabling other exporters
+				log.Errorf("enabling exporter for service %s failed: %s", service, err)
+				continue
 			}
 			log.Infof("Enabled exporter for service: %s", service)
 		}


### PR DESCRIPTION
For [#1]

This PR addresses the issue with authenticating to the cinder/block storage API which breaks due to authentication against a non-existing service `volume`.

I've also added some error handling when authentication happens before creating specific exporter, now we get the error(s) propagated back to the caller. 

If there's an error enabling a specific exporter `openstack-exporter` wont exit with a fatal error but instead log the error and continue with the next exporter.

Worth mentioning is that part of this PR can be broken into other PRs against the upstream repository with the main logic of talking to the different OpenStack APIs.