### PR TITLE
config: make sure defaults don't overwrite set values

### DIFF
--- a/config.go
+++ b/config.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"gopkg.in/yaml.v2"
 	"io/ioutil"
+
+	"github.com/creasty/defaults"
 )
 
 type CloudAuth struct {
@@ -52,6 +54,23 @@ func (config *Cloud) GetTLSConfig() (*tls.Config, error) {
 	return &tlsConfig, nil
 }
 
+func (config *Cloud) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	type cloud Cloud
+	var tmpConfig cloud
+
+	// Set the default values for config structure.
+	if err := defaults.Set(&tmpConfig); err != nil {
+		return err
+	}
+
+	if err := unmarshal(&tmpConfig); err != nil {
+		return err
+	}
+
+	*config = Cloud(tmpConfig)
+	return nil
+}
+
 func (config *CloudConfig) GetByName(name string) (*Cloud, error) {
 	cloud, ok := config.Clouds[name]
 	if !ok {
@@ -72,17 +91,10 @@ func NewCloudConfigFromByteArray(data []byte) (*CloudConfig, error) {
 }
 
 func NewCloudConfigFromFile(file string) (*CloudConfig, error) {
-	var config CloudConfig
-
 	data, err := ioutil.ReadFile(file)
 	if err != nil {
 		return nil, err
 	}
 
-	err = yaml.Unmarshal(data, &config)
-	if err != nil {
-		return nil, err
-	}
-
-	return &config, err
+	return NewCloudConfigFromByteArray(data)
 }

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfigAuthVerify(t *testing.T) {
+	const testVerifiedConnectionConfig = `
+clouds:
+ test.cloud:
+   region_name: RegionOne
+   identity_api_version: 3
+   identity_interface: internal
+   auth:
+     username: 'admin'
+     password: 'admin'
+     project_name: 'admin'
+     project_domain_name: 'Default'
+     user_domain_name: 'Default'
+     auth_url: 'http://test.cloud:35357/v3'
+`
+
+	const testUnverifiedConnectionConfig = `
+clouds:
+ test.cloud:
+   region_name: RegionOne
+   identity_api_version: 3
+   identity_interface: internal
+   auth:
+     username: 'admin'
+     password: 'admin'
+     project_name: 'admin'
+     project_domain_name: 'Default'
+     user_domain_name: 'Default'
+     auth_url: 'http://test.cloud:35357/v3'
+     verify: false
+`
+
+	cfg, err := NewCloudConfigFromByteArray([]byte(testVerifiedConnectionConfig))
+	if assert.NoError(t, err) {
+		cloud, err := cfg.GetByName("test.cloud")
+		if assert.NoError(t, err) {
+			assert.True(t, cloud.Auth.Verify)
+		}
+	}
+
+	cfg, err = NewCloudConfigFromByteArray([]byte(testUnverifiedConnectionConfig))
+	if assert.NoError(t, err) {
+		cloud, err := cfg.GetByName("test.cloud")
+		if assert.NoError(t, err) {
+			assert.False(t, cloud.Auth.Verify)
+		}
+	}
+}

--- a/main.go
+++ b/main.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/creasty/defaults"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/prometheus/common/log"
@@ -13,12 +12,6 @@ import (
 )
 
 func EnableExporter(service string, prefix string, config *Cloud) (*OpenStackExporter, error) {
-	// Set the default values for config structure.
-	err := defaults.Set(config)
-	if err != nil {
-		return nil, err
-	}
-
 	exporter, err := NewExporter(service, prefix, config)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Default config values must be applied *before* unmarshalling the actual
config, otherwise they will always overwrite set values.
