### PR TITLE
Changed method for cinder client to getting current information about…

### DIFF
--- a/cinder.go
+++ b/cinder.go
@@ -87,7 +87,7 @@ func (exporter *CinderExporter) Describe(ch chan<- *prometheus.Desc) {
 
 func (exporter *CinderExporter) Collect(ch chan<- prometheus.Metric) {
 	log.Infoln("Fetching volumes info")
-	volumes, err := exporter.Client.GetVolumesSimple(true)
+	volumes, err := exporter.Client.GetVolumesDetail(true)
 	if err != nil {
 		log.Errorf("%s", err)
 		return


### PR DESCRIPTION
Changed method for cinder client to getting current information about volumes size.
GetVolumesSimple does't return info about volume size. GetVolumesDetail return all volume details. 