### PR TITLE
Add snapcraft.yaml

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,41 @@
+name: openstack-exporter
+base: core18 # the base snap is the execution environment for this snap
+
+summary: OpenStack Exporter for Prometheus
+description: |
+  The OpenStack exporter, exports Prometheus metrics from a running OpenStack
+  cloud for consumption by prometheus. The cloud credentials and identity
+  configuration should use the os-client-config format and must by specified
+  with the --os-client-config flag.
+
+  Other options as the binding address/port can by explored with the --help
+  flag.
+
+  By default the openstack_exporter serves on port 0.0.0.0:9180 at the /metrics
+  URL.
+
+adopt-info: openstack-exporter
+confinement: strict
+
+apps:
+  openstack-exporter:
+    command: openstack-exporter
+    plugs: [home, network, network-bind]
+
+parts:
+  openstack-exporter:
+    plugin: go
+    source: ./
+    go-importpath: github.com/openstack-exporter/openstack-exporter
+    go-channel: latest/stable
+    parse-info: []
+    override-pull: |
+      snapcraftctl pull
+      version="$(git describe --tags --always --dirty)"
+      [ -n "$(echo $version | grep '-')" ] && grade=devel || grade=stable
+      snapcraftctl set-version "$version"
+      snapcraftctl set-grade "$grade"
+
+    build-packages:
+      - git
+      - build-essential


### PR DESCRIPTION
Hi

This PR adds support for building a snap package of openstack-exporter. To test this PR locally, follow  these steps in a Ubuntu machine:

```
snap install snapcraft --edge --classic
snap install multipass --edge --classic
git clone -b snap-it https://github.com/freyes/openstack-exporter
cd openstack-exporter
snapcraft
```

The generated .snap file from the tip of master can be installed with:

```
snap install openstack-exporter_v0.2.1-7-*_amd64.snap --dangerous
```

(the --dangerous is necessary because we’re installing an app which hasn’t gone through the snap store review process)

Once installed, the openstack-exporter command can be executed.

Results from my test run using a private openstack cloud:

```
$  openstack-exporter --os-client-config=./clouds.yaml default
INFO[0000] Starting openstack exporter (version=, branch=, revision=)  source="main.go:45"
INFO[0000] Build context (go=go1.12.9, user=, date=)     source="main.go:46"
INFO[0000] using TLS configured SSL connection           source="exporter.go:93"
INFO[0001] Adding metric: floating_ips to exporter: neutron  source="exporter.go:59"
INFO[0001] Adding metric: networks to exporter: neutron  source="exporter.go:59"
[...]
INFO[0099] Fetching services state information           source="cinder.go:166"
INFO[0099] Fetching regions information                  source="keystone.go:88"
INFO[0099] Fetching list of availability zones           source="nova.go:155"
INFO[0100] Fetching list of security groups              source="nova.go:164"
INFO[0101] Fetching list of security groups              source="neutron.go:96"
INFO[0102] Fetching list of servers for all tenants      source="nova.go:175"
INFO[0104] Fetching list of subnets                      source="neutron.go:102"
^C
```

Sample of the metrics captured:

```
# HELP go_gc_duration_seconds A summary of the GC invocation durations.
# TYPE go_gc_duration_seconds summary
go_gc_duration_seconds{quantile="0.0"} 1.4473e-05
go_gc_duration_seconds{quantile="0.25"} 1.6068e-05
[...]
# HELP openstack_neutron_floating_ips floating_ips
# TYPE openstack_neutron_floating_ips gauge
openstack_neutron_floating_ips{region="XXXXXX"} 88.0
[...]
```

Thanks,