### PR TITLE
Fixes SSL verification regression.

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ clouds:
      cacert: |
             ---- BEGIN CERTIFICATE ---
       ...
-     verify: true | false
+  verify: true | false  // disable || enable SSL certificate verification
 ```
 
 ## Contributing


### PR DESCRIPTION
The new library gophercloud exposes the verify option
on the auth level of the configuration.

This should be fixed and enabled at gophercloud
but in the meanwhile, I have added a new SSL transport
configuration based on the verify option.

This is related to bug: #32

Signed-off-by: Jorge Niedbalski <jnr@metaklass.org>