### PR TITLE
Without AllowReauth = True, the re-authentication uses

### DIFF
--- a/exporters/exporter.go
+++ b/exporters/exporter.go
@@ -84,8 +84,11 @@ func (exporter *BaseOpenStackExporter) CollectMetrics(ch chan<- prometheus.Metri
 func (exporter *BaseOpenStackExporter) RefreshClient() error {
 	log.Infoln("Refreshing auth client in case token has expired")
 	if err := exporter.Client.Reauthenticate(exporter.Client.Token()); err != nil {
+		log.Debugf("Error while re-authenticating client: %s", err)
 		return err
 	}
+
+	log.Infoln("Client successfully re-authenticated")
 	return nil
 }
 

--- a/exporters/utils.go
+++ b/exporters/utils.go
@@ -14,6 +14,10 @@ func AuthenticatedClient(opts *clientconfig.ClientOpts, transport *http.Transpor
 	if err != nil {
 		return nil, err
 	}
+
+	// Fixes #42
+	options.AllowReauth = true
+
 	client, err := openstack.NewClient(options.IdentityEndpoint)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
the same token even though the token might have been expired.

Setting allowreauth=true so re-authentication is enforced.

Relates to: #42

Signed-off-by: Jorge Niedbalski <jnr@metaklass.org>