### PR TITLE
Add 2 metrics to neutron

### DIFF
--- a/exporters/exporter_test.go
+++ b/exporters/exporter_test.go
@@ -164,6 +164,9 @@ func (suite *NeutronTestSuite) TestNeutronExporter() {
 	suite.SetResponseFromFixture("GET", 200,
 		suite.MakeURL("/neutron/v2.0/ports", ""),
 		suite.FixturePath("neutron_ports"),
+	suite.SetResponseFromFixture("GET", 200,
+		suite.MakeURL("/neutron/v2.0/network-ip-availabilities", ""),
+		suite.FixturePath("neutron_network_ip_availabilities"),
 	)
 
 	suite.StartMetricsHandler()

--- a/exporters/exporter_test.go
+++ b/exporters/exporter_test.go
@@ -164,6 +164,7 @@ func (suite *NeutronTestSuite) TestNeutronExporter() {
 	suite.SetResponseFromFixture("GET", 200,
 		suite.MakeURL("/neutron/v2.0/ports", ""),
 		suite.FixturePath("neutron_ports"),
+	)
 	suite.SetResponseFromFixture("GET", 200,
 		suite.MakeURL("/neutron/v2.0/network-ip-availabilities", ""),
 		suite.FixturePath("neutron_network_ip_availabilities"),

--- a/exporters/fixtures/neutron_network_ip_availabilities.json
+++ b/exporters/fixtures/neutron_network_ip_availabilities.json
@@ -1,0 +1,56 @@
+{
+    "network_ip_availabilities": [
+        {
+            "network_id": "4cf895c9-c3d1-489e-b02e-59b5c8976809",
+            "network_name": "public",
+            "subnet_ip_availability": [
+                {
+                    "cidr": "2001:db8::/64",
+                    "ip_version": 6,
+                    "subnet_id": "ca3f46c4-c6ff-4272-9be4-0466f84c6077",
+                    "subnet_name": "ipv6-public-subnet",
+                    "total_ips": 18446744073709552000,
+                    "used_ips": 1
+                },
+                {
+                    "cidr": "172.24.4.0/24",
+                    "ip_version": 4,
+                    "subnet_id": "cc02efc1-9d47-46bd-bab6-760919c836b5",
+                    "subnet_name": "public-subnet",
+                    "total_ips": 253,
+                    "used_ips": 1
+                }
+            ],
+            "project_id": "1a02cc95f1734fcc9d3c753818f03002",
+            "tenant_id": "1a02cc95f1734fcc9d3c753818f03002",
+            "total_ips": 253,
+            "used_ips": 2
+        },
+        {
+            "network_id": "6801d9c8-20e6-4b27-945d-62499f00002e",
+            "network_name": "private",
+            "subnet_ip_availability": [
+                {
+                    "cidr": "10.0.0.0/24",
+                    "ip_version": 4,
+                    "subnet_id": "44e70d00-80a2-4fb1-ab59-6190595ceb61",
+                    "subnet_name": "private-subnet",
+                    "total_ips": 253,
+                    "used_ips": 2
+                },
+                {
+                    "ip_version": 6,
+                    "cidr": "fdbf:ac66:9be8::/64",
+                    "subnet_id": "a90623df-00e1-4902-a675-40674385d74c",
+                    "subnet_name": "ipv6-private-subnet",
+                    "total_ips": 18446744073709552000,
+                    "used_ips": 2
+                }
+            ],
+            "project_id": "d56d3b8dd6894a508cf41b96b522328c",
+            "tenant_id": "d56d3b8dd6894a508cf41b96b522328c",
+            "total_ips": 18446744073709552000,
+            "used_ips": 4
+        }
+    ]
+}


### PR DESCRIPTION
I added 2 metrics to neutron:

network_ip_availabilities_total
network_ip_availabilities_used

We need these metrics to monitor the usage of floating ips and get alerts from Prometheus before we are out of floating ips of ext-net.

We use OpenStack and Prometheus in our production. We are going to use openstack-exporter to monitor our production system and contribute to this project.