### PR TITLE
Add 6 missing server_status to nova exporter"

### DIFF
--- a/exporters/nova.go
+++ b/exporters/nova.go
@@ -16,20 +16,26 @@ import (
 
 var server_status = []string{
 	"ACTIVE",
-	"BUILD",           // The server has not finished the original build process.
-	"BUILD(spawning)", // The server has not finished the original build process but networking works (HP Cloud specific)
-	"DELETED",         // The server is deleted.
-	"ERROR",           // The server is in error.
-	"HARD_REBOOT",     // The server is hard rebooting.
-	"PASSWORD",        // The password is being reset on the server.
-	"REBOOT",          // The server is in a soft reboot state.
-	"REBUILD",         // The server is currently being rebuilt from an image.
-	"RESCUE",          // The server is in rescue mode.
-	"RESIZE",          // Server is performing the differential copy of data that changed during its initial copy.
-	"SHUTOFF",         // The virtual machine (VM) was powered down by the user, but not through the OpenStack Compute API.
-	"SUSPENDED",       // The server is suspended, either by request or necessity.
-	"UNKNOWN",         // The state of the server is unknown. Contact your cloud provider.
-	"VERIFY_RESIZE",   // System is awaiting confirmation that the server is operational after a move or resize.
+	"BUILD",             // The server has not finished the original build process.
+	"BUILD(spawning)",   // The server has not finished the original build process but networking works (HP Cloud specific)
+	"DELETED",           // The server is deleted.
+	"ERROR",             // The server is in error.
+	"HARD_REBOOT",       // The server is hard rebooting.
+	"PASSWORD",          // The password is being reset on the server.
+	"REBOOT",            // The server is in a soft reboot state.
+	"REBUILD",           // The server is currently being rebuilt from an image.
+	"RESCUE",            // The server is in rescue mode.
+	"RESIZE",            // Server is performing the differential copy of data that changed during its initial copy.
+	"SHUTOFF",           // The virtual machine (VM) was powered down by the user, but not through the OpenStack Compute API.
+	"SUSPENDED",         // The server is suspended, either by request or necessity.
+	"UNKNOWN",           // The state of the server is unknown. Contact your cloud provider.
+	"VERIFY_RESIZE",     // System is awaiting confirmation that the server is operational after a move or resize.
+	"MIGRATING",         // The server is migrating. This is caused by a live migration (moving a server that is active) action.
+	"PAUSED",            // The server is paused.
+	"REVERT_RESIZE",     // The resize or migration of a server failed for some reason. The destination server is being cleaned up and the original source server is restarting.
+	"SHELVED",           // The server is in shelved state. Depends on the shelve offload time, the server will be automatically shelved off loaded.
+	"SHELVED_OFFLOADED", // The shelved server is offloaded (removed from the compute host) and it needs unshelved action to be used again.
+	"SOFT_DELETED",      // The server is marked as deleted but will remain in the cloud for some configurable amount of time.
 }
 
 func mapServerStatus(current string) int {


### PR DESCRIPTION
I added 6 missing server_status to nova exporter. 
https://docs.openstack.org/api-guide/compute/server_concepts.html

I didn't delete any thing. I didn't change the order of old server_status too, to make sure this commit will not break the configurations of other users. 

It's my editor that aligned all comments :)