### PR TITLE
Add --disable-metric parameter.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ executors:
   # Whenever the Go version is updated here, .promu.yml should also be updated.
   golang:
     docker:
-    - image: circleci/golang:1.11
+    - image: circleci/golang:1.13
 
 jobs:
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Flags:
       --disable-service.volume   Disable the volume service exporter
       --disable-service.identity
                                  Disable the identity service exporter
+      --disable-metric
 
 Args:
   <cloud>  name or id of the cloud to gather metrics from

--- a/exporters/cinder.go
+++ b/exporters/cinder.go
@@ -55,12 +55,13 @@ var defaultCinderMetrics = []Metric{
 	{Name: "volume_status", Labels: []string{"id", "name", "status", "bootable", "tenant_id", "size", "volume_type"}, Fn: nil},
 }
 
-func NewCinderExporter(client *gophercloud.ServiceClient, prefix string) (*CinderExporter, error) {
+func NewCinderExporter(client *gophercloud.ServiceClient, prefix string, disabledMetrics []string) (*CinderExporter, error) {
 	exporter := CinderExporter{
 		BaseOpenStackExporter{
-			Name:   "cinder",
-			Prefix: prefix,
-			Client: client,
+			Name:            "cinder",
+			Prefix:          prefix,
+			Client:          client,
+			DisabledMetrics: disabledMetrics,
 		},
 	}
 	for _, metric := range defaultCinderMetrics {

--- a/exporters/exporter_test.go
+++ b/exporters/exporter_test.go
@@ -75,7 +75,7 @@ func (suite *BaseOpenStackTestSuite) TearDownSuite() {
 
 func (suite *BaseOpenStackTestSuite) SetupTest() {
 	os.Setenv("OS_CLIENT_CONFIG_FILE", path.Join(baseFixturePath, "test_config.yaml"))
-	exporter, err := EnableExporter(suite.ServiceName, suite.Prefix, cloudName)
+	exporter, err := EnableExporter(suite.ServiceName, suite.Prefix, cloudName, []string{})
 	if err != nil {
 		panic(err)
 	}

--- a/exporters/glance.go
+++ b/exporters/glance.go
@@ -15,12 +15,13 @@ var defaultGlanceMetrics = []Metric{
 	{Name: "images", Fn: ListImages},
 }
 
-func NewGlanceExporter(client *gophercloud.ServiceClient, prefix string) (*GlanceExporter, error) {
+func NewGlanceExporter(client *gophercloud.ServiceClient, prefix string, disabledMetrics []string) (*GlanceExporter, error) {
 	exporter := GlanceExporter{
 		BaseOpenStackExporter{
-			Name:   "glance",
-			Prefix: prefix,
-			Client: client,
+			Name:            "glance",
+			Prefix:          prefix,
+			Client:          client,
+			DisabledMetrics: disabledMetrics,
 		},
 	}
 

--- a/exporters/keystone.go
+++ b/exporters/keystone.go
@@ -23,12 +23,13 @@ var defaultKeystoneMetrics = []Metric{
 	{Name: "regions", Fn: ListRegions},
 }
 
-func NewKeystoneExporter(client *gophercloud.ServiceClient, prefix string) (*KeystoneExporter, error) {
+func NewKeystoneExporter(client *gophercloud.ServiceClient, prefix string, disabledMetrics []string) (*KeystoneExporter, error) {
 	exporter := KeystoneExporter{
 		BaseOpenStackExporter{
-			Name:   "identity",
-			Prefix: prefix,
-			Client: client,
+			Name:            "identity",
+			Prefix:          prefix,
+			Client:          client,
+			DisabledMetrics: disabledMetrics,
 		},
 	}
 

--- a/exporters/neutron.go
+++ b/exporters/neutron.go
@@ -31,12 +31,13 @@ var defaultNeutronMetrics = []Metric{
 	{Name: "network_ip_availabilities_used", Labels: []string{"network_id", "network_name", "cidr", "subnet_name", "project_id"}},
 }
 
-func NewNeutronExporter(client *gophercloud.ServiceClient, prefix string) (*NeutronExporter, error) {
+func NewNeutronExporter(client *gophercloud.ServiceClient, prefix string, disabledMetrics []string) (*NeutronExporter, error) {
 	exporter := NeutronExporter{
 		BaseOpenStackExporter{
-			Name:   "neutron",
-			Prefix: prefix,
-			Client: client,
+			Name:            "neutron",
+			Prefix:          prefix,
+			Client:          client,
+			DisabledMetrics: disabledMetrics,
 		},
 	}
 

--- a/exporters/nova.go
+++ b/exporters/nova.go
@@ -69,12 +69,13 @@ var defaultNovaMetrics = []Metric{
 		"address_ipv6", "host_id", "uuid", "availability_zone", "flavor_id"}},
 }
 
-func NewNovaExporter(client *gophercloud.ServiceClient, prefix string) (*NovaExporter, error) {
+func NewNovaExporter(client *gophercloud.ServiceClient, prefix string, disabledMetrics []string) (*NovaExporter, error) {
 	exporter := NovaExporter{
 		BaseOpenStackExporter{
-			Name:   "nova",
-			Prefix: prefix,
-			Client: client,
+			Name:            "nova",
+			Prefix:          prefix,
+			Client:          client,
+			DisabledMetrics: disabledMetrics,
 		},
 	}
 	for _, metric := range defaultNovaMetrics {

--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,6 @@ require (
 	github.com/gophercloud/utils v0.0.0-20191020172814-bd86af96d544
 	github.com/gorilla/mux v1.7.3
 	github.com/jarcoal/httpmock v1.0.4
-	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/prometheus/client_golang v1.2.1
 	github.com/prometheus/common v0.7.0
 	github.com/stretchr/testify v1.4.0


### PR DESCRIPTION
This commit adds a new parameter --disable-metric (short d)
that allows to specify a metric to be skip from collection.

The format has to be --disable-metric service_name-metric,
some examples are:

--disable-metric cinder-snapshots
--disable-metric nova-servers

This issue refers to #55