### PR TITLE
Add endpoint-type parameter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,24 +68,24 @@ usage: openstack-exporter [<flags>] <cloud>
 
 Flags:
   -h, --help                     Show context-sensitive help (also try --help-long and --help-man).
-      --web.listen-address=":9180"
+      --web.listen-address=":9180"  
                                  address:port to listen on
-      --web.telemetry-path="/metrics"
+      --web.telemetry-path="/metrics"  
                                  uri path to expose metrics
-      --os-client-config="/etc/openstack/clouds.yml"
+      --os-client-config="/etc/openstack/clouds.yaml"  
                                  Path to the cloud configuration file
       --prefix="openstack"       Prefix for metrics
+      --endpoint-type="public"   openstack endpoint type to use (i.e: public, internal, admin)
+  -d, --disable-metric= ...      multiple --disable-metric can be specified in the format: service-metric (i.e: cinder-snapshots)
       --disable-service.network  Disable the network service exporter
       --disable-service.compute  Disable the compute service exporter
       --disable-service.image    Disable the image service exporter
       --disable-service.volume   Disable the volume service exporter
-      --disable-service.identity
+      --disable-service.identity  
                                  Disable the identity service exporter
-      --disable-metric
 
 Args:
   <cloud>  name or id of the cloud to gather metrics from
-
 ```
 
 ### OpenStack configuration

--- a/exporters/exporter.go
+++ b/exporters/exporter.go
@@ -37,8 +37,8 @@ type OpenStackExporter interface {
 	RefreshClient() error
 }
 
-func EnableExporter(service, prefix, cloud string, disabledMetrics []string) (*OpenStackExporter, error) {
-	exporter, err := NewExporter(service, prefix, cloud, disabledMetrics)
+func EnableExporter(service, prefix, cloud string, disabledMetrics []string, endpointType string) (*OpenStackExporter, error) {
+	exporter, err := NewExporter(service, prefix, cloud, disabledMetrics, endpointType)
 	if err != nil {
 		return nil, err
 	}
@@ -131,7 +131,7 @@ func (exporter *BaseOpenStackExporter) AddMetric(name string, fn ListFunc, label
 	}
 }
 
-func NewExporter(name, prefix, cloud string, disabledMetrics []string) (OpenStackExporter, error) {
+func NewExporter(name, prefix, cloud string, disabledMetrics []string, endpointType string) (OpenStackExporter, error) {
 	var exporter OpenStackExporter
 	var err error
 	var transport *http.Transport
@@ -149,7 +149,7 @@ func NewExporter(name, prefix, cloud string, disabledMetrics []string) (OpenStac
 		transport = &http.Transport{TLSClientConfig: tlsConfig}
 	}
 
-	client, err := NewServiceClient(name, &opts, transport)
+	client, err := NewServiceClient(name, &opts, transport, endpointType)
 	if err != nil {
 		return nil, err
 	}

--- a/exporters/exporter_test.go
+++ b/exporters/exporter_test.go
@@ -75,7 +75,7 @@ func (suite *BaseOpenStackTestSuite) TearDownSuite() {
 
 func (suite *BaseOpenStackTestSuite) SetupTest() {
 	os.Setenv("OS_CLIENT_CONFIG_FILE", path.Join(baseFixturePath, "test_config.yaml"))
-	exporter, err := EnableExporter(suite.ServiceName, suite.Prefix, cloudName, []string{})
+	exporter, err := EnableExporter(suite.ServiceName, suite.Prefix, cloudName, []string{}, "public")
 	if err != nil {
 		panic(err)
 	}

--- a/exporters/utils.go
+++ b/exporters/utils.go
@@ -35,7 +35,7 @@ func AuthenticatedClient(opts *clientconfig.ClientOpts, transport *http.Transpor
 }
 
 // NewServiceClient is a convenience function to get a new service client.
-func NewServiceClient(service string, opts *clientconfig.ClientOpts, transport *http.Transport) (*gophercloud.ServiceClient, error) {
+func NewServiceClient(service string, opts *clientconfig.ClientOpts, transport *http.Transport, endpointType string) (*gophercloud.ServiceClient, error) {
 	cloud := new(clientconfig.Cloud)
 
 	// If no opts were passed in, create an empty ClientOpts.
@@ -96,7 +96,8 @@ func NewServiceClient(service string, opts *clientconfig.ClientOpts, transport *
 	}
 
 	eo := gophercloud.EndpointOpts{
-		Region: region,
+		Region:       region,
+		Availability: GetEndpointType(endpointType),
 	}
 
 	switch service {
@@ -155,4 +156,14 @@ func NewServiceClient(service string, opts *clientconfig.ClientOpts, transport *
 	}
 
 	return nil, fmt.Errorf("unable to create a service client for %s", service)
+}
+
+func GetEndpointType(endpointType string) gophercloud.Availability {
+	if endpointType == "internal" || endpointType == "internalURL" {
+		return gophercloud.AvailabilityInternal
+	}
+	if endpointType == "admin" || endpointType == "adminURL" {
+		return gophercloud.AvailabilityAdmin
+	}
+	return gophercloud.AvailabilityPublic
 }

--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ func main() {
 		metrics         = kingpin.Flag("web.telemetry-path", "uri path to expose metrics").Default("/metrics").String()
 		osClientConfig  = kingpin.Flag("os-client-config", "Path to the cloud configuration file").Default(DEFAULT_OS_CLIENT_CONFIG).String()
 		prefix          = kingpin.Flag("prefix", "Prefix for metrics").Default("openstack").String()
+		endpointType    = kingpin.Flag("endpoint-type", "openstack endpoint type to use (i.e: public, internal, admin)").Default("public").String()
 		disabledMetrics = kingpin.Flag("disable-metric", "multiple --disable-metric can be specified in the format: service-metric (i.e: cinder-snapshots)").Default("").Short('d').Strings()
 		cloud           = kingpin.Arg("cloud", "name or id of the cloud to gather metrics from").Required().String()
 	)
@@ -46,7 +47,7 @@ func main() {
 	enabledExporters := 0
 	for service, disabled := range services {
 		if !*disabled {
-			_, err := exporters.EnableExporter(service, *prefix, *cloud, *disabledMetrics)
+			_, err := exporters.EnableExporter(service, *prefix, *cloud, *disabledMetrics, *endpointType)
 			if err != nil {
 				// Log error and continue with enabling other exporters
 				log.Errorf("enabling exporter for service %s failed: %s", service, err)


### PR DESCRIPTION
Since gophercloud utils for clientconfig
doesn't support parsing the identity-type option
we are exposing the --endpoint-type parameter
that defaults to public.

Related to bug #57

Signed-off-by: Jorge Niedbalski <jnr@metaklass.org>