### PR TITLE
Fix setting AZ label. (Match host in the proper way)

### DIFF
--- a/exporters/nova.go
+++ b/exporters/nova.go
@@ -142,7 +142,7 @@ func ListHypervisors(exporter *BaseOpenStackExporter, ch chan<- prometheus.Metri
 
 	for _, hypervisor := range allHypervisors {
 		availabilityZone := ""
-		if val, ok := hostToAggregateMap[hypervisor.HypervisorHostname]; ok {
+		if val, ok := hostToAggregateMap[hypervisor.Service.Host]; ok {
 			availabilityZone = val
 		}
 


### PR DESCRIPTION
This is a fix to make the `availability_zone` label work properly.

**The issue**
When getting the list of hosts from an aggregate as coded [here](https://github.com/openstack-exporter/openstack-exporter/blob/baa6fc19196b573664a1f1dc7d6beb411be76541/exporters/nova.go#L136), what you get returned is the 'service host name' of the hypervisor.

Then when iterating over all hypervisors, you shouldn't try to find that same host in the `hostToAggregateMap` using `hypervisor.HypervisorHostname`. ([See here](https://github.com/openstack-exporter/openstack-exporter/blob/baa6fc19196b573664a1f1dc7d6beb411be76541/exporters/nova.go#L145)). The hypervisor hostname is potentially not the same as the service host name of that hypervisor. For example, within our company the hypervisor hostname is something like `os-az-west-host-01.openstack.local`, while the service host name (a.k.a. Compute Host) is `os-az-west-host-01`.

**The fix**
This PR fixes this issue by searching in the map using `hypervisor.Service.Host`, which equals/matches with the hostnames from the [Host](https://github.com/openstack-exporter/openstack-exporter/blob/baa6fc19196b573664a1f1dc7d6beb411be76541/exporters/nova.go#L136) field from the `Aggregate` object type. 