### PR TITLE
Improve testing and add ip_version to availabilities

### DIFF
--- a/exporters/cinder_test.go
+++ b/exporters/cinder_test.go
@@ -1,0 +1,52 @@
+package exporters
+
+import (
+	"strings"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+type CinderTestSuite struct {
+	BaseOpenStackTestSuite
+}
+
+var cinderExpectedUp = `
+# HELP openstack_cinder_agent_state agent_state
+# TYPE openstack_cinder_agent_state counter
+openstack_cinder_agent_state{adminState="enabled",hostname="devstack",service="cinder-backup",zone="nova"} 1
+openstack_cinder_agent_state{adminState="enabled",hostname="devstack",service="cinder-scheduler",zone="nova"} 1
+openstack_cinder_agent_state{adminState="enabled",hostname="devstack@lvmdriver-1",service="cinder-volume",zone="nova"} 1
+# HELP openstack_cinder_snapshots snapshots
+# TYPE openstack_cinder_snapshots gauge
+openstack_cinder_snapshots 1
+# HELP openstack_cinder_up up
+# TYPE openstack_cinder_up gauge
+openstack_cinder_up 1
+# HELP openstack_cinder_volume_status volume_status
+# TYPE openstack_cinder_volume_status gauge
+openstack_cinder_volume_status{bootable="false",id="6edbc2f4-1507-44f8-ac0d-eed1d2608d38",name="test-volume-attachments",size="2",status="in-use",tenant_id="bab7d5c60cd041a0a36f7c4b6e1dd978",volume_type="lvmdriver-1"} 5
+openstack_cinder_volume_status{bootable="true",id="173f7b48-c4c1-4e70-9acc-086b39073506",name="test-volume",size="1",status="available",tenant_id="bab7d5c60cd041a0a36f7c4b6e1dd978",volume_type="lvmdriver-1"} 1
+# HELP openstack_cinder_volumes volumes
+# TYPE openstack_cinder_volumes gauge
+openstack_cinder_volumes 2
+`
+
+var cinderExpectedDown = `
+# HELP openstack_cinder_up up
+# TYPE openstack_cinder_up gauge
+openstack_cinder_up 0
+`
+
+func (suite *CinderTestSuite) TestCinderExporter() {
+	err := testutil.CollectAndCompare(*suite.Exporter, strings.NewReader(cinderExpectedUp))
+	assert.NoError(suite.T(), err)
+}
+
+func (suite *CinderTestSuite) TestCinderExporterWithEndpointDown() {
+	suite.teardownFixtures()
+	defer suite.installFixtures()
+
+	err := testutil.CollectAndCompare(*suite.Exporter, strings.NewReader(cinderExpectedDown))
+	assert.NoError(suite.T(), err)
+}

--- a/exporters/glance_test.go
+++ b/exporters/glance_test.go
@@ -1,0 +1,40 @@
+package exporters
+
+import (
+	"strings"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+type GlanceTestSuite struct {
+	BaseOpenStackTestSuite
+}
+
+var glanceExpectedUp = `
+# HELP openstack_glance_images images
+# TYPE openstack_glance_images gauge
+openstack_glance_images 2
+# HELP openstack_glance_up up
+# TYPE openstack_glance_up gauge
+openstack_glance_up 1
+`
+
+var glanceExpectedDown = `
+# HELP openstack_glance_up up
+# TYPE openstack_glance_up gauge
+openstack_glance_up 0
+`
+
+func (suite *GlanceTestSuite) TestGlanceExporter() {
+	err := testutil.CollectAndCompare(*suite.Exporter, strings.NewReader(glanceExpectedUp))
+	assert.NoError(suite.T(), err)
+}
+
+func (suite *GlanceTestSuite) TestGlanceExporterWithEndpointDown() {
+	suite.teardownFixtures()
+	defer suite.installFixtures()
+
+	err := testutil.CollectAndCompare(*suite.Exporter, strings.NewReader(glanceExpectedDown))
+	assert.NoError(suite.T(), err)
+}

--- a/exporters/keystone_test.go
+++ b/exporters/keystone_test.go
@@ -1,0 +1,1 @@
+package exporters

--- a/exporters/neutron.go
+++ b/exporters/neutron.go
@@ -27,8 +27,8 @@ var defaultNeutronMetrics = []Metric{
 	{Name: "ports", Fn: ListPorts},
 	{Name: "routers", Fn: ListRouters},
 	{Name: "agent_state", Labels: []string{"hostname", "service", "adminState"}, Fn: ListAgentStates},
-	{Name: "network_ip_availabilities_total", Labels: []string{"network_id", "network_name", "cidr", "subnet_name", "project_id"}, Fn: ListNetworkIPAvailabilities},
-	{Name: "network_ip_availabilities_used", Labels: []string{"network_id", "network_name", "cidr", "subnet_name", "project_id"}},
+	{Name: "network_ip_availabilities_total", Labels: []string{"network_id", "network_name", "ip_version", "cidr", "subnet_name", "project_id"}, Fn: ListNetworkIPAvailabilities},
+	{Name: "network_ip_availabilities_used", Labels: []string{"network_id", "network_name", "ip_version", "cidr", "subnet_name", "project_id"}},
 }
 
 func NewNeutronExporter(client *gophercloud.ServiceClient, prefix string, disabledMetrics []string) (*NeutronExporter, error) {
@@ -190,7 +190,7 @@ func ListNetworkIPAvailabilities(exporter *BaseOpenStackExporter, ch chan<- prom
 			}
 			ch <- prometheus.MustNewConstMetric(exporter.Metrics["network_ip_availabilities_total"].Metric,
 				prometheus.GaugeValue, totalIPs, NetworkIPAvailabilities.NetworkID,
-				NetworkIPAvailabilities.NetworkName, SubnetIPAvailability.CIDR,
+				NetworkIPAvailabilities.NetworkName, strconv.Itoa(SubnetIPAvailability.IPVersion), SubnetIPAvailability.CIDR,
 				SubnetIPAvailability.SubnetName, NetworkIPAvailabilities.ProjectID)
 
 			usedIPs, err := strconv.ParseFloat(SubnetIPAvailability.UsedIPs, 64)
@@ -199,7 +199,7 @@ func ListNetworkIPAvailabilities(exporter *BaseOpenStackExporter, ch chan<- prom
 			}
 			ch <- prometheus.MustNewConstMetric(exporter.Metrics["network_ip_availabilities_used"].Metric,
 				prometheus.GaugeValue, usedIPs, NetworkIPAvailabilities.NetworkID,
-				NetworkIPAvailabilities.NetworkName, SubnetIPAvailability.CIDR,
+				NetworkIPAvailabilities.NetworkName, strconv.Itoa(SubnetIPAvailability.IPVersion), SubnetIPAvailability.CIDR,
 				SubnetIPAvailability.SubnetName, NetworkIPAvailabilities.ProjectID)
 		}
 	}

--- a/exporters/neutron_test.go
+++ b/exporters/neutron_test.go
@@ -23,16 +23,16 @@ openstack_neutron_agent_state{adminState="up",hostname="agenthost1",service="neu
 openstack_neutron_floating_ips 3
 # HELP openstack_neutron_network_ip_availabilities_total network_ip_availabilities_total
 # TYPE openstack_neutron_network_ip_availabilities_total gauge
-openstack_neutron_network_ip_availabilities_total{cidr="10.0.0.0/24",network_id="6801d9c8-20e6-4b27-945d-62499f00002e",network_name="private",project_id="d56d3b8dd6894a508cf41b96b522328c",subnet_name="private-subnet"} 253
-openstack_neutron_network_ip_availabilities_total{cidr="172.24.4.0/24",network_id="4cf895c9-c3d1-489e-b02e-59b5c8976809",network_name="public",project_id="1a02cc95f1734fcc9d3c753818f03002",subnet_name="public-subnet"} 253
-openstack_neutron_network_ip_availabilities_total{cidr="2001:db8::/64",network_id="4cf895c9-c3d1-489e-b02e-59b5c8976809",network_name="public",project_id="1a02cc95f1734fcc9d3c753818f03002",subnet_name="ipv6-public-subnet"} 1.8446744073709552e+19
-openstack_neutron_network_ip_availabilities_total{cidr="fdbf:ac66:9be8::/64",network_id="6801d9c8-20e6-4b27-945d-62499f00002e",network_name="private",project_id="d56d3b8dd6894a508cf41b96b522328c",subnet_name="ipv6-private-subnet"} 1.8446744073709552e+19
+openstack_neutron_network_ip_availabilities_total{cidr="10.0.0.0/24",ip_version="4",network_id="6801d9c8-20e6-4b27-945d-62499f00002e",network_name="private",project_id="d56d3b8dd6894a508cf41b96b522328c",subnet_name="private-subnet"} 253
+openstack_neutron_network_ip_availabilities_total{cidr="172.24.4.0/24",ip_version="4",network_id="4cf895c9-c3d1-489e-b02e-59b5c8976809",network_name="public",project_id="1a02cc95f1734fcc9d3c753818f03002",subnet_name="public-subnet"} 253
+openstack_neutron_network_ip_availabilities_total{cidr="2001:db8::/64",ip_version="6",network_id="4cf895c9-c3d1-489e-b02e-59b5c8976809",network_name="public",project_id="1a02cc95f1734fcc9d3c753818f03002",subnet_name="ipv6-public-subnet"} 1.8446744073709552e+19
+openstack_neutron_network_ip_availabilities_total{cidr="fdbf:ac66:9be8::/64",ip_version="6",network_id="6801d9c8-20e6-4b27-945d-62499f00002e",network_name="private",project_id="d56d3b8dd6894a508cf41b96b522328c",subnet_name="ipv6-private-subnet"} 1.8446744073709552e+19
 # HELP openstack_neutron_network_ip_availabilities_used network_ip_availabilities_used
 # TYPE openstack_neutron_network_ip_availabilities_used gauge
-openstack_neutron_network_ip_availabilities_used{cidr="10.0.0.0/24",network_id="6801d9c8-20e6-4b27-945d-62499f00002e",network_name="private",project_id="d56d3b8dd6894a508cf41b96b522328c",subnet_name="private-subnet"} 2
-openstack_neutron_network_ip_availabilities_used{cidr="172.24.4.0/24",network_id="4cf895c9-c3d1-489e-b02e-59b5c8976809",network_name="public",project_id="1a02cc95f1734fcc9d3c753818f03002",subnet_name="public-subnet"} 1
-openstack_neutron_network_ip_availabilities_used{cidr="2001:db8::/64",network_id="4cf895c9-c3d1-489e-b02e-59b5c8976809",network_name="public",project_id="1a02cc95f1734fcc9d3c753818f03002",subnet_name="ipv6-public-subnet"} 1
-openstack_neutron_network_ip_availabilities_used{cidr="fdbf:ac66:9be8::/64",network_id="6801d9c8-20e6-4b27-945d-62499f00002e",network_name="private",project_id="d56d3b8dd6894a508cf41b96b522328c",subnet_name="ipv6-private-subnet"} 2
+openstack_neutron_network_ip_availabilities_used{cidr="10.0.0.0/24",ip_version="4",network_id="6801d9c8-20e6-4b27-945d-62499f00002e",network_name="private",project_id="d56d3b8dd6894a508cf41b96b522328c",subnet_name="private-subnet"} 2
+openstack_neutron_network_ip_availabilities_used{cidr="172.24.4.0/24",ip_version="4",network_id="4cf895c9-c3d1-489e-b02e-59b5c8976809",network_name="public",project_id="1a02cc95f1734fcc9d3c753818f03002",subnet_name="public-subnet"} 1
+openstack_neutron_network_ip_availabilities_used{cidr="2001:db8::/64",ip_version="6",network_id="4cf895c9-c3d1-489e-b02e-59b5c8976809",network_name="public",project_id="1a02cc95f1734fcc9d3c753818f03002",subnet_name="ipv6-public-subnet"} 1
+openstack_neutron_network_ip_availabilities_used{cidr="fdbf:ac66:9be8::/64",ip_version="6",network_id="6801d9c8-20e6-4b27-945d-62499f00002e",network_name="private",project_id="d56d3b8dd6894a508cf41b96b522328c",subnet_name="ipv6-private-subnet"} 2
 # HELP openstack_neutron_networks networks
 # TYPE openstack_neutron_networks gauge
 openstack_neutron_networks 0

--- a/exporters/neutron_test.go
+++ b/exporters/neutron_test.go
@@ -1,0 +1,73 @@
+package exporters
+
+import (
+	"strings"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+type NeutronTestSuite struct {
+	BaseOpenStackTestSuite
+}
+
+var neutronExpectedUp = `
+# HELP openstack_neutron_agent_state agent_state
+# TYPE openstack_neutron_agent_state counter
+openstack_neutron_agent_state{adminState="up",hostname="agenthost1",service="neutron-dhcp-agent"} 1
+openstack_neutron_agent_state{adminState="up",hostname="agenthost1",service="neutron-l3-agent"} 1
+openstack_neutron_agent_state{adminState="up",hostname="agenthost1",service="neutron-metadata-agent"} 1
+openstack_neutron_agent_state{adminState="up",hostname="agenthost1",service="neutron-openvswitch-agent"} 1
+# HELP openstack_neutron_floating_ips floating_ips
+# TYPE openstack_neutron_floating_ips gauge
+openstack_neutron_floating_ips 3
+# HELP openstack_neutron_network_ip_availabilities_total network_ip_availabilities_total
+# TYPE openstack_neutron_network_ip_availabilities_total gauge
+openstack_neutron_network_ip_availabilities_total{cidr="10.0.0.0/24",network_id="6801d9c8-20e6-4b27-945d-62499f00002e",network_name="private",project_id="d56d3b8dd6894a508cf41b96b522328c",subnet_name="private-subnet"} 253
+openstack_neutron_network_ip_availabilities_total{cidr="172.24.4.0/24",network_id="4cf895c9-c3d1-489e-b02e-59b5c8976809",network_name="public",project_id="1a02cc95f1734fcc9d3c753818f03002",subnet_name="public-subnet"} 253
+openstack_neutron_network_ip_availabilities_total{cidr="2001:db8::/64",network_id="4cf895c9-c3d1-489e-b02e-59b5c8976809",network_name="public",project_id="1a02cc95f1734fcc9d3c753818f03002",subnet_name="ipv6-public-subnet"} 1.8446744073709552e+19
+openstack_neutron_network_ip_availabilities_total{cidr="fdbf:ac66:9be8::/64",network_id="6801d9c8-20e6-4b27-945d-62499f00002e",network_name="private",project_id="d56d3b8dd6894a508cf41b96b522328c",subnet_name="ipv6-private-subnet"} 1.8446744073709552e+19
+# HELP openstack_neutron_network_ip_availabilities_used network_ip_availabilities_used
+# TYPE openstack_neutron_network_ip_availabilities_used gauge
+openstack_neutron_network_ip_availabilities_used{cidr="10.0.0.0/24",network_id="6801d9c8-20e6-4b27-945d-62499f00002e",network_name="private",project_id="d56d3b8dd6894a508cf41b96b522328c",subnet_name="private-subnet"} 2
+openstack_neutron_network_ip_availabilities_used{cidr="172.24.4.0/24",network_id="4cf895c9-c3d1-489e-b02e-59b5c8976809",network_name="public",project_id="1a02cc95f1734fcc9d3c753818f03002",subnet_name="public-subnet"} 1
+openstack_neutron_network_ip_availabilities_used{cidr="2001:db8::/64",network_id="4cf895c9-c3d1-489e-b02e-59b5c8976809",network_name="public",project_id="1a02cc95f1734fcc9d3c753818f03002",subnet_name="ipv6-public-subnet"} 1
+openstack_neutron_network_ip_availabilities_used{cidr="fdbf:ac66:9be8::/64",network_id="6801d9c8-20e6-4b27-945d-62499f00002e",network_name="private",project_id="d56d3b8dd6894a508cf41b96b522328c",subnet_name="ipv6-private-subnet"} 2
+# HELP openstack_neutron_networks networks
+# TYPE openstack_neutron_networks gauge
+openstack_neutron_networks 0
+# HELP openstack_neutron_ports ports
+# TYPE openstack_neutron_ports gauge
+openstack_neutron_ports 2
+# HELP openstack_neutron_routers routers
+# TYPE openstack_neutron_routers gauge
+openstack_neutron_routers 0
+# HELP openstack_neutron_security_groups security_groups
+# TYPE openstack_neutron_security_groups gauge
+openstack_neutron_security_groups 1
+# HELP openstack_neutron_subnets subnets
+# TYPE openstack_neutron_subnets gauge
+openstack_neutron_subnets 2
+# HELP openstack_neutron_up up
+# TYPE openstack_neutron_up gauge
+openstack_neutron_up 1
+`
+
+var neutronExpectedDown = `
+# HELP openstack_neutron_up up
+# TYPE openstack_neutron_up gauge
+openstack_neutron_up 0
+`
+
+func (suite *NeutronTestSuite) TestNeutronExporter() {
+	err := testutil.CollectAndCompare(*suite.Exporter, strings.NewReader(neutronExpectedUp))
+	assert.NoError(suite.T(), err)
+}
+
+func (suite *NeutronTestSuite) TestNeutronExporterWithEndpointDown() {
+	suite.teardownFixtures()
+	defer suite.installFixtures()
+
+	err := testutil.CollectAndCompare(*suite.Exporter, strings.NewReader(neutronExpectedDown))
+	assert.NoError(suite.T(), err)
+}

--- a/exporters/nova_test.go
+++ b/exporters/nova_test.go
@@ -1,0 +1,122 @@
+package exporters
+
+import (
+	"strings"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+type NovaTestSuite struct {
+	BaseOpenStackTestSuite
+}
+
+var novaExpectedUp = `
+# HELP openstack_nova_agent_state agent_state
+# TYPE openstack_nova_agent_state counter
+openstack_nova_agent_state{adminState="disabled",hostname="host1",id="1",service="nova-scheduler",zone="internal"} 1
+openstack_nova_agent_state{adminState="disabled",hostname="host1",id="2",service="nova-compute",zone="nova"} 1
+openstack_nova_agent_state{adminState="disabled",hostname="host2",id="4",service="nova-compute",zone="nova"} 0
+openstack_nova_agent_state{adminState="enabled",hostname="host2",id="3",service="nova-scheduler",zone="internal"} 0
+# HELP openstack_nova_availability_zones availability_zones
+# TYPE openstack_nova_availability_zones gauge
+openstack_nova_availability_zones 1
+# HELP openstack_nova_current_workload current_workload
+# TYPE openstack_nova_current_workload gauge
+openstack_nova_current_workload{aggregates="",availability_zone="",hostname="host1"} 0
+# HELP openstack_nova_flavors flavors
+# TYPE openstack_nova_flavors gauge
+openstack_nova_flavors 7
+# HELP openstack_nova_limits_memory_max limits_memory_max
+# TYPE openstack_nova_limits_memory_max gauge
+openstack_nova_limits_memory_max{tenant="admin"} 51200
+openstack_nova_limits_memory_max{tenant="alt_demo"} 51200
+openstack_nova_limits_memory_max{tenant="demo"} 51200
+openstack_nova_limits_memory_max{tenant="invisible_to_admin"} 51200
+openstack_nova_limits_memory_max{tenant="service"} 51200
+openstack_nova_limits_memory_max{tenant="swifttenanttest1"} 51200
+openstack_nova_limits_memory_max{tenant="swifttenanttest2"} 51200
+openstack_nova_limits_memory_max{tenant="swifttenanttest4"} 51200
+# HELP openstack_nova_limits_memory_used limits_memory_used
+# TYPE openstack_nova_limits_memory_used gauge
+openstack_nova_limits_memory_used{tenant="admin"} 0
+openstack_nova_limits_memory_used{tenant="alt_demo"} 0
+openstack_nova_limits_memory_used{tenant="demo"} 0
+openstack_nova_limits_memory_used{tenant="invisible_to_admin"} 0
+openstack_nova_limits_memory_used{tenant="service"} 0
+openstack_nova_limits_memory_used{tenant="swifttenanttest1"} 0
+openstack_nova_limits_memory_used{tenant="swifttenanttest2"} 0
+openstack_nova_limits_memory_used{tenant="swifttenanttest4"} 0
+# HELP openstack_nova_limits_vcpus_max limits_vcpus_max
+# TYPE openstack_nova_limits_vcpus_max gauge
+openstack_nova_limits_vcpus_max{tenant="admin"} 20
+openstack_nova_limits_vcpus_max{tenant="alt_demo"} 20
+openstack_nova_limits_vcpus_max{tenant="demo"} 20
+openstack_nova_limits_vcpus_max{tenant="invisible_to_admin"} 20
+openstack_nova_limits_vcpus_max{tenant="service"} 20
+openstack_nova_limits_vcpus_max{tenant="swifttenanttest1"} 20
+openstack_nova_limits_vcpus_max{tenant="swifttenanttest2"} 20
+openstack_nova_limits_vcpus_max{tenant="swifttenanttest4"} 20
+# HELP openstack_nova_limits_vcpus_used limits_vcpus_used
+# TYPE openstack_nova_limits_vcpus_used gauge
+openstack_nova_limits_vcpus_used{tenant="admin"} 0
+openstack_nova_limits_vcpus_used{tenant="alt_demo"} 0
+openstack_nova_limits_vcpus_used{tenant="demo"} 0
+openstack_nova_limits_vcpus_used{tenant="invisible_to_admin"} 0
+openstack_nova_limits_vcpus_used{tenant="service"} 0
+openstack_nova_limits_vcpus_used{tenant="swifttenanttest1"} 0
+openstack_nova_limits_vcpus_used{tenant="swifttenanttest2"} 0
+openstack_nova_limits_vcpus_used{tenant="swifttenanttest4"} 0
+# HELP openstack_nova_local_storage_available_bytes local_storage_available_bytes
+# TYPE openstack_nova_local_storage_available_bytes gauge
+openstack_nova_local_storage_available_bytes{aggregates="",availability_zone="",hostname="host1"} 1.103806595072e+12
+# HELP openstack_nova_local_storage_used_bytes local_storage_used_bytes
+# TYPE openstack_nova_local_storage_used_bytes gauge
+openstack_nova_local_storage_used_bytes{aggregates="",availability_zone="",hostname="host1"} 0
+# HELP openstack_nova_memory_available_bytes memory_available_bytes
+# TYPE openstack_nova_memory_available_bytes gauge
+openstack_nova_memory_available_bytes{aggregates="",availability_zone="",hostname="host1"} 8.589934592e+09
+# HELP openstack_nova_memory_used_bytes memory_used_bytes
+# TYPE openstack_nova_memory_used_bytes gauge
+openstack_nova_memory_used_bytes{aggregates="",availability_zone="",hostname="host1"} 5.36870912e+08
+# HELP openstack_nova_running_vms running_vms
+# TYPE openstack_nova_running_vms gauge
+openstack_nova_running_vms{aggregates="",availability_zone="",hostname="host1"} 0
+# HELP openstack_nova_security_groups security_groups
+# TYPE openstack_nova_security_groups gauge
+openstack_nova_security_groups 1
+# HELP openstack_nova_server_status server_status
+# TYPE openstack_nova_server_status gauge
+openstack_nova_server_status{address_ipv4="1.2.3.4",address_ipv6="80fe::",availability_zone="nova",flavor_id="<nil>",host_id="2091634baaccdc4c5a1d57069c833e402921df696b7f970791b12ec6",id="2ce4c5b3-2866-4972-93ce-77a2ea46a7f9",name="new-server-test",status="ACTIVE",tenant_id="6f70656e737461636b20342065766572",user_id="fake",uuid="2ce4c5b3-2866-4972-93ce-77a2ea46a7f9"} 0
+# HELP openstack_nova_total_vms total_vms
+# TYPE openstack_nova_total_vms gauge
+openstack_nova_total_vms 1
+# HELP openstack_nova_up up
+# TYPE openstack_nova_up gauge
+openstack_nova_up 1
+# HELP openstack_nova_vcpus_available vcpus_available
+# TYPE openstack_nova_vcpus_available gauge
+openstack_nova_vcpus_available{aggregates="",availability_zone="",hostname="host1"} 2
+# HELP openstack_nova_vcpus_used vcpus_used
+# TYPE openstack_nova_vcpus_used gauge
+openstack_nova_vcpus_used{aggregates="",availability_zone="",hostname="host1"} 0
+`
+
+var novaExpectedDown = `
+# HELP openstack_nova_up up
+# TYPE openstack_nova_up gauge
+openstack_nova_up 0
+`
+
+func (suite *NovaTestSuite) TestNovaExporter() {
+	err := testutil.CollectAndCompare(*suite.Exporter, strings.NewReader(novaExpectedUp))
+	assert.NoError(suite.T(), err)
+}
+
+func (suite *NovaTestSuite) TestNovaExporterWithEndpointDown() {
+	suite.teardownFixtures()
+	defer suite.installFixtures()
+
+	err := testutil.CollectAndCompare(*suite.Exporter, strings.NewReader(novaExpectedDown))
+	assert.NoError(suite.T(), err)
+}

--- a/go.mod
+++ b/go.mod
@@ -5,10 +5,9 @@ go 1.13
 require (
 	github.com/gophercloud/gophercloud v0.6.0
 	github.com/gophercloud/utils v0.0.0-20191129022341-463e26ffa30d
-	github.com/gorilla/mux v1.7.3
 	github.com/jarcoal/httpmock v1.0.4
 	github.com/prometheus/client_golang v1.2.1
-	github.com/prometheus/client_model v0.0.0-20191202183732-d1d2010b5bee
+	github.com/prometheus/client_model v0.0.0-20191202183732-d1d2010b5bee // indirect
 	github.com/prometheus/common v0.7.0
 	github.com/stretchr/testify v1.4.0
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6

--- a/go.sum
+++ b/go.sum
@@ -31,8 +31,6 @@ github.com/gophercloud/gophercloud v0.6.0 h1:Xb2lcqZtml1XjgYZxbeayEemq7ASbeTp09m
 github.com/gophercloud/gophercloud v0.6.0/go.mod h1:GICNByuaEBibcjmjvI7QvYJSZEbGkcYwAR7EZK2WMqM=
 github.com/gophercloud/utils v0.0.0-20191129022341-463e26ffa30d h1:lHwkWOlNjHUNDVdoOacrVD/UKqLn/xsEGyD8JBATv9Y=
 github.com/gophercloud/utils v0.0.0-20191129022341-463e26ffa30d/go.mod h1:SZ9FTKibIotDtCrxAU/evccoyu1yhKST6hgBvwTB5Eg=
-github.com/gorilla/mux v1.7.3 h1:gnP5JzjVOuiZD07fKKToCAOjS0yOpj/qPETTXCCS6hw=
-github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/jarcoal/httpmock v1.0.4 h1:jp+dy/+nonJE4g4xbVtl9QdrUNbn6/3hDT5R4nDIZnA=
 github.com/jarcoal/httpmock v1.0.4/go.mod h1:ATjnClrvW/3tijVmpL/va5Z3aAyGvqU3gCT8nX0Txik=


### PR DESCRIPTION
This change improves the testing for the exporter, now testing actual values!  It also fixes a few missing mocks and makes the test fail if there is any missing mocks.

It also adds ip_version which is really useful for checking for IP availability.