### PR TITLE
New Neutron metrics + inconsistency checks

### DIFF
--- a/exporters/exporter_test.go
+++ b/exporters/exporter_test.go
@@ -79,6 +79,7 @@ var fixtures map[string]string = map[string]string{
 	"/neutron/v2.0/ports":                      "neutron_ports",
 	"/neutron/v2.0/network-ip-availabilities":  "neutron_network_ip_availabilities",
 	"/neutron/v2.0/routers":                    "neutron_routers",
+	"/neutron/v2.0/lbaas/loadbalancers":        "neutron_loadbalancers",
 	"/volumes":                                 "cinder_api_discovery",
 	"/volumes/volumes/detail?all_tenants=true": "cinder_volumes",
 	"/volumes/snapshots":                       "cinder_snapshots",

--- a/exporters/fixtures/neutron_agents.json
+++ b/exporters/fixtures/neutron_agents.json
@@ -1,125 +1,145 @@
 {
-  "agents": [
-    {
-      "binary": "neutron-openvswitch-agent",
-      "description": null,
-      "availability_zone": null,
-      "heartbeat_timestamp": "2017-09-12 19:40:08",
-      "admin_state_up": true,
-      "alive": true,
-      "id":" 04c62b91-b799-48b7-9cd5-2982db6df9c6",
-      "topic": "N/A",
-      "host": "agenthost1",
-      "agent_type": "Open vSwitch agent",
-      "started_at": "2017-09-12 19:35:38",
-      "created_at": "2017-09-12 19:35:38",
-      "configurations": {
-        "ovs_hybrid_plug": true,
-        "in_distributed_mode": false,
-        "datapath_type": "system",
-        "vhostuser_socket_dir": "/var/run/openvswitch",
-        "tunneling_ip": "172.16.78.191",
-        "arp_responder_enabled": false,
-        "devices": 0,
-        "ovs_capabilities": {
-          "datapath_types": [
-            "netdev",
-            "system"
-          ],
-          "iface_types": [
-            "geneve",
-            "gre",
-            "internal",
-            "ipsec_gre",
-            "lisp",
-            "patch",
-            "stt",
-            "system",
-            "tap",
-            "vxlan"
-          ]
+    "agents": [
+        {
+            "binary": "neutron-openvswitch-agent",
+            "description": null,
+            "availability_zone": null,
+            "heartbeat_timestamp": "2017-09-12 19:40:08",
+            "admin_state_up": true,
+            "alive": true,
+            "id": " 04c62b91-b799-48b7-9cd5-2982db6df9c6",
+            "topic": "N/A",
+            "host": "agenthost1",
+            "agent_type": "Open vSwitch agent",
+            "started_at": "2017-09-12 19:35:38",
+            "created_at": "2017-09-12 19:35:38",
+            "configurations": {
+                "ovs_hybrid_plug": true,
+                "in_distributed_mode": false,
+                "datapath_type": "system",
+                "vhostuser_socket_dir": "/var/run/openvswitch",
+                "tunneling_ip": "172.16.78.191",
+                "arp_responder_enabled": false,
+                "devices": 0,
+                "ovs_capabilities": {
+                    "datapath_types": [
+                        "netdev",
+                        "system"
+                    ],
+                    "iface_types": [
+                        "geneve",
+                        "gre",
+                        "internal",
+                        "ipsec_gre",
+                        "lisp",
+                        "patch",
+                        "stt",
+                        "system",
+                        "tap",
+                        "vxlan"
+                    ]
+                },
+                "log_agent_heartbeats": false,
+                "l2_population": false,
+                "tunnel_types": [
+                    "vxlan"
+                ],
+                "extensions": [],
+                "enable_distributed_routing": false,
+                "bridge_mappings": {
+                    "public": "br-ex"
+                }
+            }
         },
-        "log_agent_heartbeats": false,
-        "l2_population": false,
-        "tunnel_types": [
-          "vxlan"
-        ],
-        "extensions": [
-
-        ],
-        "enable_distributed_routing": false,
-        "bridge_mappings": {
-          "public": "br-ex"
+        {
+            "binary": "neutron-dhcp-agent",
+            "description": null,
+            "availability_zone": "nova",
+            "heartbeat_timestamp": "2017-09-12 19:39:56",
+            "admin_state_up": true,
+            "alive": true,
+            "id": "840d5d68-5759-4e9e-812f-f3bd19214c7f",
+            "topic": "dhcp_agent",
+            "host": "agenthost1",
+            "agent_type": "DHCP agent",
+            "started_at": "2017-09-12 19:35:36",
+            "created_at": "2017-09-12 19:35:36",
+            "configurations": {
+                "subnets": 2,
+                "dhcp_lease_duration": 86400,
+                "dhcp_driver": "neutron.agent.linux.dhcp.Dnsmasq",
+                "networks": 1,
+                "log_agent_heartbeats": false,
+                "ports": 3
+            }
+        },
+        {
+            "binary": "neutron-l3-agent",
+            "description": null,
+            "availability_zone": "nova",
+            "heartbeat_timestamp": "2017-09-12 19:40:08",
+            "admin_state_up": true,
+            "alive": true,
+            "id": "a09b81fc-5a42-46d3-a306-1a5d122a7787",
+            "topic": "l3_agent",
+            "host": "agenthost1",
+            "agent_type": "L3 agent",
+            "started_at": "2017-09-12 19:35:38",
+            "created_at": "2017-09-12 19:35:38",
+            "configurations": {
+                "agent_mode": "legacy",
+                "gateway_external_network_id": "",
+                "handle_internal_only_routers": true,
+                "routers": 2,
+                "interfaces": 2,
+                "floating_ips": 0,
+                "interface_driver": "openvswitch",
+                "log_agent_heartbeats": false,
+                "external_network_bridge": "",
+                "ex_gw_ports": 1
+            }
+        },
+        {
+            "binary": "neutron-metadata-agent",
+            "description": null,
+            "availability_zone": null,
+            "heartbeat_timestamp": "2017-09-12 19:40:09",
+            "admin_state_up": true,
+            "alive": true,
+            "id": "c876c9f7-1058-4b9b-90ed-20fb3f905ec4",
+            "topic": "N/A",
+            "host": "agenthost1",
+            "agent_type": "Metadata agent",
+            "started_at": "2017-09-12 19:35:39",
+            "created_at": "2017-09-12 19:35:39",
+            "configurations": {
+                "log_agent_heartbeats": false,
+                "nova_metadata_host": "172.16.78.191",
+                "nova_metadata_port": 8775,
+                "metadata_proxy_socket": "/opt/stack/data/neutron/metadata_proxy"
+            }
+        },
+        {
+            "binary": "neutron-lbaasv2-agent",
+            "started_at": "2020-01-16 13:18:26",
+            "description": null,
+            "heartbeat_timestamp": "2020-02-06 16:40:42",
+            "availability_zone": null,
+            "created_at": "2018-04-05 14:35:52",
+            "admin_state_up": true,
+            "alive": true,
+            "topic": "n-lbaasv2_agent",
+            "host": "agenthost1",
+            "ha_state": null,
+            "agent_type": "Loadbalancerv2 agent",
+            "configuration": {
+                "device_drivers": [
+                    "haproxy_ns"
+                ],
+                "instances": 1
+            },
+            "id": "2bf84eaf-d869-49cc-8401-cbbca5177e59",
+            "name": null
         }
-      }
-    },
-    {
-      "binary": "neutron-dhcp-agent",
-      "description": null,
-      "availability_zone": "nova",
-      "heartbeat_timestamp": "2017-09-12 19:39:56",
-      "admin_state_up": true,
-      "alive": true,
-      "id": "840d5d68-5759-4e9e-812f-f3bd19214c7f",
-      "topic": "dhcp_agent",
-      "host": "agenthost1",
-      "agent_type" :"DHCP agent",
-      "started_at": "2017-09-12 19:35:36",
-      "created_at": "2017-09-12 19:35:36",
-      "configurations": {
-        "subnets": 2,
-        "dhcp_lease_duration": 86400,
-        "dhcp_driver": "neutron.agent.linux.dhcp.Dnsmasq",
-        "networks": 1,
-        "log_agent_heartbeats": false,
-        "ports": 3
-      }
-    },
-    {
-      "binary": "neutron-l3-agent",
-      "description": null,
-      "availability_zone": "nova",
-      "heartbeat_timestamp": "2017-09-12 19:40:08",
-      "admin_state_up": true,
-      "alive": true,
-      "id": "a09b81fc-5a42-46d3-a306-1a5d122a7787",
-      "topic": "l3_agent",
-      "host": "agenthost1",
-      "agent_type": "L3 agent",
-      "started_at": "2017-09-12 19:35:38",
-      "created_at": "2017-09-12 19:35:38",
-      "configurations": {
-        "agent_mode": "legacy",
-        "gateway_external_network_id": "",
-        "handle_internal_only_routers": true,
-        "routers": 1,
-        "interfaces": 2,
-        "floating_ips": 0,
-        "interface_driver": "openvswitch",
-        "log_agent_heartbeats": false,
-        "external_network_bridge": "",
-        "ex_gw_ports": 1
-      }
-    },
-    {
-      "binary": "neutron-metadata-agent",
-      "description": null,
-      "availability_zone": null,
-      "heartbeat_timestamp": "2017-09-12 19:40:09",
-      "admin_state_up": true,
-      "alive": true,
-      "id": "c876c9f7-1058-4b9b-90ed-20fb3f905ec4",
-      "topic": "N/A",
-      "host": "agenthost1",
-      "agent_type": "Metadata agent",
-      "started_at": "2017-09-12 19:35:39",
-      "created_at": "2017-09-12 19:35:39",
-      "configurations": {
-        "log_agent_heartbeats": false,
-        "nova_metadata_host": "172.16.78.191",
-        "nova_metadata_port": 8775,
-        "metadata_proxy_socket": "/opt/stack/data/neutron/metadata_proxy"
-      }
-    }
-  ]
+    ]
 }

--- a/exporters/fixtures/neutron_loadbalancers.json
+++ b/exporters/fixtures/neutron_loadbalancers.json
@@ -1,0 +1,20 @@
+{
+    "loadbalancers": [
+        {
+            "name": "lb1",
+            "provisioning_status": "ACTIVE",
+            "tenant_id": "3427c6640406418e8368081fd4fff18c",
+            "vip_address": "172.16.36.93",
+            "provider": "haproxy",
+            "id": "00f3453d-8738-4eb6-b362-a4ec8dfaeea6"
+        },
+        {
+            "name": "lb2",
+            "provisioning_status": "ACTIVE",
+            "tenant_id": "807911f7cc834838b3c6eddbb71024fa",
+            "vip_address": "172.16.36.32",
+            "provider": "haproxy",
+            "id": "02814fe3-369f-4b2a-abec-d94ce45303ce"
+        }
+    ]
+}

--- a/exporters/fixtures/neutron_ports.json
+++ b/exporters/fixtures/neutron_ports.json
@@ -1,92 +1,142 @@
 {
-"ports": [
-{
-"admin_state_up": true,
-"allowed_address_pairs": [],
-"created_at": "2016-03-08T20:19:41",
-"data_plane_status": null,
-"description": "",
-"device_id": "9ae135f4-b6e0-4dad-9e91-3c223e385824",
-"device_owner": "network:router_gateway",
-"dns_assignment": {
-"hostname": "myport",
-"ip_address": "172.24.4.2",
-"fqdn": "myport.my-domain.org"
-},
-"dns_domain": "my-domain.org.",
-"dns_name": "myport",
-"extra_dhcp_opts": [
-{
-"opt_value": "pxelinux.0",
-"ip_version": 4,
-"opt_name": "bootfile-name"
-}
-],
-"fixed_ips": [
-{
-"ip_address": "172.24.4.2",
-"subnet_id": "008ba151-0b8c-4a67-98b5-0d2b87666062"
-}
-],
-"id": "d80b1a3b-4fc1-49f3-952e-1e2ab7081d8b",
-"ip_allocation": "immediate",
-"mac_address": "fa:16:3e:58:42:ed",
-"name": "",
-"network_id": "70c1db1f-b701-45bd-96e0-a313ee3430b3",
-"project_id": "",
-"revision_number": 1,
-"security_groups": [],
-"status": "ACTIVE",
-"tags": ["tag1,tag2"],
-"tenant_id": "",
-"updated_at": "2016-03-08T20:19:41",
-"qos_policy_id": "29d5e02e-d5ab-4929-bee4-4a9fc12e22ae",
-"port_security_enabled": false,
-"uplink_status_propagation": false
-},
-{
-"admin_state_up": true,
-"allowed_address_pairs": [],
-"created_at": "2016-03-08T20:19:41",
-"data_plane_status": null,
-"description": "",
-"device_id": "9ae135f4-b6e0-4dad-9e91-3c223e385824",
-"device_owner": "network:router_interface",
-"dns_assignment": {
-"hostname": "myport2",
-"ip_address": "10.0.0.1",
-"fqdn": "myport2.my-domain.org"
-},
-"dns_domain": "my-domain.org.",
-"dns_name": "myport2",
-"extra_dhcp_opts": [
-{
-"opt_value": "pxelinux.0",
-"ip_version": 4,
-"opt_name": "bootfile-name"
-}
-],
-"fixed_ips": [
-{
-"ip_address": "10.0.0.1",
-"subnet_id": "288bf4a1-51ba-43b6-9d0a-520e9005db17"
-}
-],
-"id": "f71a6703-d6de-4be1-a91a-a570ede1d159",
-"ip_allocation": "immediate",
-"mac_address": "fa:16:3e:bb:3c:e4",
-"name": "",
-"network_id": "f27aa545-cbdd-4907-b0c6-c9e8b039dcc2",
-"project_id": "d397de8a63f341818f198abb0966f6f3",
-"revision_number": 1,
-"security_groups": [],
-"status": "ACTIVE",
-"tags": ["tag1,tag2"],
-"tenant_id": "d397de8a63f341818f198abb0966f6f3",
-"updated_at": "2016-03-08T20:19:41",
-"qos_policy_id": null,
-"port_security_enabled": false,
-"uplink_status_propagation": false
-}
-]
+    "ports": [
+        {
+            "admin_state_up": true,
+            "allowed_address_pairs": [],
+            "created_at": "2016-03-08T20:19:41",
+            "data_plane_status": null,
+            "description": "",
+            "device_id": "9ae135f4-b6e0-4dad-9e91-3c223e385824",
+            "device_owner": "network:router_gateway",
+            "dns_assignment": {
+                "hostname": "myport",
+                "ip_address": "172.24.4.2",
+                "fqdn": "myport.my-domain.org"
+            },
+            "dns_domain": "my-domain.org.",
+            "dns_name": "myport",
+            "extra_dhcp_opts": [
+                {
+                    "opt_value": "pxelinux.0",
+                    "ip_version": 4,
+                    "opt_name": "bootfile-name"
+                }
+            ],
+            "fixed_ips": [],
+            "id": "d80b1a3b-4fc1-49f3-952e-1e2ab7081d8b",
+            "ip_allocation": "immediate",
+            "mac_address": "fa:16:3e:58:42:ed",
+            "name": "",
+            "network_id": "70c1db1f-b701-45bd-96e0-a313ee3430b3",
+            "project_id": "",
+            "revision_number": 1,
+            "security_groups": [],
+            "status": "ACTIVE",
+            "tags": [
+                "tag1,tag2"
+            ],
+            "tenant_id": "",
+            "updated_at": "2016-03-08T20:19:41",
+            "qos_policy_id": "29d5e02e-d5ab-4929-bee4-4a9fc12e22ae",
+            "port_security_enabled": false,
+            "uplink_status_propagation": false
+        },
+        {
+            "admin_state_up": true,
+            "allowed_address_pairs": [],
+            "created_at": "2016-03-08T20:19:41",
+            "data_plane_status": null,
+            "description": "",
+            "device_id": "9ae135f4-b6e0-4dad-9e91-3c223e385824",
+            "device_owner": "network:router_interface",
+            "dns_assignment": {
+                "hostname": "myport2",
+                "ip_address": "10.0.0.1",
+                "fqdn": "myport2.my-domain.org"
+            },
+            "dns_domain": "my-domain.org.",
+            "dns_name": "myport2",
+            "extra_dhcp_opts": [
+                {
+                    "opt_value": "pxelinux.0",
+                    "ip_version": 4,
+                    "opt_name": "bootfile-name"
+                }
+            ],
+            "fixed_ips": [
+                {
+                    "ip_address": "10.0.0.1",
+                    "subnet_id": "288bf4a1-51ba-43b6-9d0a-520e9005db17"
+                }
+            ],
+            "id": "f71a6703-d6de-4be1-a91a-a570ede1d159",
+            "ip_allocation": "immediate",
+            "mac_address": "fa:16:3e:bb:3c:e4",
+            "name": "",
+            "network_id": "f27aa545-cbdd-4907-b0c6-c9e8b039dcc2",
+            "project_id": "d397de8a63f341818f198abb0966f6f3",
+            "revision_number": 1,
+            "security_groups": [],
+            "status": "ACTIVE",
+            "tags": [
+                "tag1,tag2"
+            ],
+            "tenant_id": "d397de8a63f341818f198abb0966f6f3",
+            "updated_at": "2016-03-08T20:19:41",
+            "qos_policy_id": null,
+            "port_security_enabled": false,
+            "uplink_status_propagation": false
+        },
+        {
+            "admin_state_up": true,
+            "allowed_address_pairs": [],
+            "created_at": "2016-03-08T20:19:41",
+            "data_plane_status": null,
+            "description": "",
+            "device_id": "f1cf2214-9f5d-49e2-b79e-276062f3cc25",
+            "device_owner": "neutron:LOADBALANCERV2",
+            "dns_assignment": {
+                "hostname": "myport2",
+                "ip_address": "10.0.0.1",
+                "fqdn": "myport2.my-domain.org"
+            },
+            "dns_domain": "my-domain.org.",
+            "dns_name": "myport2",
+            "extra_dhcp_opts": [
+                {
+                    "opt_value": "pxelinux.0",
+                    "ip_version": 4,
+                    "opt_name": "bootfile-name"
+                }
+            ],
+            "fixed_ips": [
+                {
+                    "ip_address": "192.168.36.198",
+                    "subnet_id": "9261d4e6-c584-4690-a3de-5393079d29a0"
+                }
+            ],
+            "id": "f0b24508-eb48-4530-a38b-c042df147101",
+            "mac_address": "fa:16:3e:0b:14:fd",
+            "name": "loadbalancer-f1cf2214-9f5d-49e2-b79e-276062f3cc25",
+            "network_id": "675c54a5-a9f3-4f5e-a0b4-e026b29c217b",
+            "project_id": "9c3d692eeef34c5b8fc5686ab29837f1",
+            "revision_number": 1,
+            "security_groups": [],
+            "status": "N/A",
+            "tags": [
+                "tag1,tag2"
+            ],
+            "tenant_id": "d397de8a63f341818f198abb0966f6f3",
+            "updated_at": "2016-03-08T20:19:41",
+            "qos_policy_id": null,
+            "port_security_enabled": true,
+            "trunk_details": null,
+            "security_group_ids": "2ccd3d98-af37-4969-bff2-9b2b6f9b3dd6",
+            "binding_host_id": "host11111",
+            "binding_profile": "",
+            "binding_vif_type": "ovs",
+            "binding_vif_details": "datapath_type='system', ovs_hybrid_plug='True', port_filter='True'",
+            "binding_vnic_type": "normal"
+        }
+    ]
 }

--- a/exporters/fixtures/neutron_routers.json
+++ b/exporters/fixtures/neutron_routers.json
@@ -1,44 +1,83 @@
 {
-    "router": {
-        "admin_state_up": true,
-        "availability_zone_hints": [],
-        "availability_zones": [
-            "nova"
-        ],
-        "created_at": "2018-03-19T19:17:04Z",
-        "description": "",
-        "distributed": false,
-        "external_gateway_info": {
-            "enable_snat": true,
-            "external_fixed_ips": [
+    "router": [
+        {
+            "admin_state_up": true,
+            "availability_zone_hints": [],
+            "availability_zones": [
+                "nova"
+            ],
+            "created_at": "2018-03-19T19:17:04Z",
+            "description": "",
+            "distributed": false,
+            "external_gateway_info": {
+                "enable_snat": true,
+                "external_fixed_ips": [
+                    {
+                        "ip_address": "172.24.4.6",
+                        "subnet_id": "b930d7f6-ceb7-40a0-8b81-a425dd994ccf"
+                    },
+                    {
+                        "ip_address": "2001:db8::9",
+                        "subnet_id": "0c56df5d-ace5-46c8-8f4c-45fa4e334d18"
+                    }
+                ],
+                "network_id": "ae34051f-aa6c-4c75-abf5-50dc9ac99ef3"
+            },
+            "flavor_id": "f7b14d9a-b0dc-4fbe-bb14-a0f4970a69e0",
+            "ha": false,
+            "id": "f8a44de0-fc8e-45df-93c7-f79bf3b01c95",
+            "name": "router1",
+            "revision_number": 1,
+            "routes": [
                 {
-                    "ip_address": "172.24.4.6",
-                    "subnet_id": "b930d7f6-ceb7-40a0-8b81-a425dd994ccf"
-                },
-                {
-                    "ip_address": "2001:db8::9",
-                    "subnet_id": "0c56df5d-ace5-46c8-8f4c-45fa4e334d18"
+                    "destination": "179.24.1.0/24",
+                    "nexthop": "172.24.3.99"
                 }
             ],
-            "network_id": "ae34051f-aa6c-4c75-abf5-50dc9ac99ef3"
+            "status": "ACTIVE",
+            "updated_at": "2018-03-19T19:17:22Z",
+            "project_id": "0bd18306d801447bb457a46252d82d13",
+            "tenant_id": "0bd18306d801447bb457a46252d82d13",
+            "service_type_id": null,
+            "tags": [
+                "tag1,tag2"
+            ],
+            "conntrack_helpers": []
         },
-        "flavor_id": "f7b14d9a-b0dc-4fbe-bb14-a0f4970a69e0",
-        "ha": false,
-        "id": "f8a44de0-fc8e-45df-93c7-f79bf3b01c95",
-        "name": "router1",
-        "revision_number": 1,
-        "routes": [
-            {
-                "destination": "179.24.1.0/24",
-                "nexthop": "172.24.3.99"
-            }
-        ],
-        "status": "ACTIVE",
-        "updated_at": "2018-03-19T19:17:22Z",
-        "project_id": "0bd18306d801447bb457a46252d82d13",
-        "tenant_id": "0bd18306d801447bb457a46252d82d13",
-        "service_type_id": null,
-        "tags": ["tag1,tag2"],
-        "conntrack_helpers": []
-    }
+        {
+            "admin_state_up": true,
+            "availability_zone_hints": [],
+            "availability_zones": [
+                "nova"
+            ],
+            "created_at": "2018-05-28T15:52:43Z",
+            "description": "",
+            "distributed": true,
+            "external_gateway_info": {
+                "enable_snat": true,
+                "external_fixed_ips": [
+                    {
+                        "ip_address": "10.0.0.8",
+                        "subnet_id": "58689be2-f2fc-436c-af3a-acb157ce5cb0"
+                    }
+                ],
+                "network_id": "6507357c-48ad-4715-b79b-496dbbdf95ec"
+            },
+            "flavor_id": "f7b14d9a-b0dc-4fbe-bb14-a0f4970a69e0",
+            "ha": true,
+            "id": "9daeb7dd-7e3f-4e44-8c42-c7a0e8c8a42f",
+            "name": "router2",
+            "revision_number": 1,
+            "routes": "destination='192.168.32.0/24', gateway='192.168.36.10'",
+            "status": "N/A",
+            "updated_at": "2019-06-29T17:53:11Z",
+            "project_id": "d91418ac90044a91bfadb7b0d21666f1",
+            "tenant_id": "0bd18306d801447bb457a46252d82d13",
+            "service_type_id": null,
+            "tags": [
+                "tag1,tag2"
+            ],
+            "conntrack_helpers": []
+        }
+    ]
 }

--- a/exporters/neutron_test.go
+++ b/exporters/neutron_test.go
@@ -16,11 +16,18 @@ var neutronExpectedUp = `
 # TYPE openstack_neutron_agent_state counter
 openstack_neutron_agent_state{adminState="up",hostname="agenthost1",service="neutron-dhcp-agent"} 1
 openstack_neutron_agent_state{adminState="up",hostname="agenthost1",service="neutron-l3-agent"} 1
+openstack_neutron_agent_state{adminState="up",hostname="agenthost1",service="neutron-lbaasv2-agent"} 1
 openstack_neutron_agent_state{adminState="up",hostname="agenthost1",service="neutron-metadata-agent"} 1
 openstack_neutron_agent_state{adminState="up",hostname="agenthost1",service="neutron-openvswitch-agent"} 1
 # HELP openstack_neutron_floating_ips floating_ips
 # TYPE openstack_neutron_floating_ips gauge
 openstack_neutron_floating_ips 3
+# HELP openstack_neutron_loadbalancers loadbalancers
+# TYPE openstack_neutron_loadbalancers gauge
+openstack_neutron_loadbalancers 2
+# HELP openstack_neutron_loadbalancers_not_active loadbalancers_not_active
+# TYPE openstack_neutron_loadbalancers_not_active gauge
+openstack_neutron_loadbalancers_not_active 0
 # HELP openstack_neutron_network_ip_availabilities_total network_ip_availabilities_total
 # TYPE openstack_neutron_network_ip_availabilities_total gauge
 openstack_neutron_network_ip_availabilities_total{cidr="10.0.0.0/24",ip_version="4",network_id="6801d9c8-20e6-4b27-945d-62499f00002e",network_name="private",project_id="d56d3b8dd6894a508cf41b96b522328c",subnet_name="private-subnet"} 253
@@ -38,10 +45,19 @@ openstack_neutron_network_ip_availabilities_used{cidr="fdbf:ac66:9be8::/64",ip_v
 openstack_neutron_networks 0
 # HELP openstack_neutron_ports ports
 # TYPE openstack_neutron_ports gauge
-openstack_neutron_ports 2
+openstack_neutron_ports 3
+# HELP openstack_neutron_ports_no_ips ports_no_ips
+# TYPE openstack_neutron_ports_no_ips gauge
+openstack_neutron_ports_no_ips 1
+# HELP openstack_neutron_ports_lb_not_active ports_lb_not_active
+# TYPE openstack_neutron_ports_lb_not_active gauge
+openstack_neutron_ports_lb_not_active 1
 # HELP openstack_neutron_routers routers
 # TYPE openstack_neutron_routers gauge
 openstack_neutron_routers 0
+# HELP openstack_neutron_routers_not_active routers_not_active
+# TYPE openstack_neutron_routers_not_active gauge
+openstack_neutron_routers_not_active 0
 # HELP openstack_neutron_security_groups security_groups
 # TYPE openstack_neutron_security_groups gauge
 openstack_neutron_security_groups 1


### PR DESCRIPTION
- Added basic loadbalancer metrics
- Added metrics for inconsistencies checks (ports without IPs, ...)

These metrics were needed for our monitoring of our clusters (we have about a dozen clusters for all kind of environments) but they might be useful to a broader audience.