### PR TITLE
Performance improvements + port status addition

### DIFF
--- a/exporters/exporter_test.go
+++ b/exporters/exporter_test.go
@@ -25,18 +25,18 @@ type BaseOpenStackTestSuite struct {
 }
 
 func (suite *BaseOpenStackTestSuite) SetResponseFromFixture(method string, statusCode int, url string, file string) {
-	httpmock.RegisterResponder(method, url, func(request *http.Request) (*http.Response, error) {
-		data, _ := ioutil.ReadFile(file)
-		return &http.Response{
-			Body: ioutil.NopCloser(bytes.NewReader(data)),
-			Header: http.Header{
-				"Content-Type":    []string{"application/json"},
-				"X-Subject-Token": []string{"1234"},
-			},
-			StatusCode: statusCode,
-			Request:    request,
-		}, nil
-	})
+	data, _ := ioutil.ReadFile(file)
+	response := &http.Response{
+		Body: ioutil.NopCloser(bytes.NewReader(data)),
+		Header: http.Header{
+			"Content-Type":    []string{"application/json"},
+			"X-Subject-Token": []string{"1234"},
+		},
+		StatusCode: statusCode,
+	}
+
+	responder := httpmock.ResponderFromResponse(response).Once()
+	httpmock.RegisterResponder(method, url, responder)
 }
 
 func (suite *BaseOpenStackTestSuite) MakeURL(resource string, port string) string {

--- a/exporters/fixtures/neutron_ports.json
+++ b/exporters/fixtures/neutron_ports.json
@@ -132,11 +132,11 @@
             "port_security_enabled": true,
             "trunk_details": null,
             "security_group_ids": "2ccd3d98-af37-4969-bff2-9b2b6f9b3dd6",
-            "binding_host_id": "host11111",
-            "binding_profile": "",
-            "binding_vif_type": "ovs",
-            "binding_vif_details": "datapath_type='system', ovs_hybrid_plug='True', port_filter='True'",
-            "binding_vnic_type": "normal"
+            "binding:host_id": "host11111",
+            "binding:profile": {},
+            "binding:vif_type": "ovs",
+            "binding:vif_details": {"port_filter":true,"bridge_name":"br-int","datapath_type":"system","ovs_hybrid_plug":true},
+            "binding:vnic_type": "normal"
         }
     ]
 }

--- a/exporters/neutron.go
+++ b/exporters/neutron.go
@@ -24,7 +24,7 @@ type NeutronExporter struct {
 
 var defaultNeutronMetrics = []Metric{
 	{Name: "floating_ips", Fn: ListFloatingIps},
-	{Name: "floating_ips_associated_not_active", Fn: ListFloatingIpsAssociatedNotActive},
+	{Name: "floating_ips_associated_not_active"},
 	{Name: "networks", Fn: ListNetworks},
 	{Name: "security_groups", Fn: ListSecGroups},
 	{Name: "subnets", Fn: ListSubnets},
@@ -33,12 +33,12 @@ var defaultNeutronMetrics = []Metric{
 	{Name: "ports_no_ips"},
 	{Name: "ports_lb_not_active"},
 	{Name: "routers", Fn: ListRouters},
-	{Name: "routers_not_active", Fn: ListRoutersNotActive},
+	{Name: "routers_not_active"},
 	{Name: "agent_state", Labels: []string{"hostname", "service", "adminState"}, Fn: ListAgentStates},
 	{Name: "network_ip_availabilities_total", Labels: []string{"network_id", "network_name", "ip_version", "cidr", "subnet_name", "project_id"}, Fn: ListNetworkIPAvailabilities},
 	{Name: "network_ip_availabilities_used", Labels: []string{"network_id", "network_name", "ip_version", "cidr", "subnet_name", "project_id"}},
 	{Name: "loadbalancers", Fn: ListLBs},
-	{Name: "loadbalancers_not_active", Fn: ListLBsNotActive},
+	{Name: "loadbalancers_not_active"},
 }
 
 // NewNeutronExporter : returns a pointer to NeutronExporter
@@ -59,27 +59,8 @@ func NewNeutronExporter(client *gophercloud.ServiceClient, prefix string, disabl
 	return &exporter, nil
 }
 
-// ListFloatingIps : count total number of instantiated FloatingIPs
+// ListFloatingIps : count total number of instantiated FloatingIPs and those that are associated to private IP but not in ACTIVE state
 func ListFloatingIps(exporter *BaseOpenStackExporter, ch chan<- prometheus.Metric) error {
-	var allFloatingIPs []floatingips.FloatingIP
-
-	allPagesFloatingIPs, err := floatingips.List(exporter.Client, floatingips.ListOpts{}).AllPages()
-	if err != nil {
-		return err
-	}
-
-	allFloatingIPs, err = floatingips.ExtractFloatingIPs(allPagesFloatingIPs)
-	if err != nil {
-		return err
-	}
-	ch <- prometheus.MustNewConstMetric(exporter.Metrics["floating_ips"].Metric,
-		prometheus.GaugeValue, float64(len(allFloatingIPs)))
-
-	return nil
-}
-
-// ListFloatingIpsAssociatedNotActive : count total number of instantiated FloatingIPs that are associated to private IP but not in ACTIVE state
-func ListFloatingIpsAssociatedNotActive(exporter *BaseOpenStackExporter, ch chan<- prometheus.Metric) error {
 	var allFloatingIPs []floatingips.FloatingIP
 
 	allPagesFloatingIPs, err := floatingips.List(exporter.Client, floatingips.ListOpts{}).AllPages()
@@ -101,6 +82,8 @@ func ListFloatingIpsAssociatedNotActive(exporter *BaseOpenStackExporter, ch chan
 		}
 	}
 
+	ch <- prometheus.MustNewConstMetric(exporter.Metrics["floating_ips"].Metric,
+		prometheus.GaugeValue, float64(len(allFloatingIPs)))
 	ch <- prometheus.MustNewConstMetric(exporter.Metrics["floating_ips_associated_not_active"].Metric,
 		prometheus.GaugeValue, float64(failedFIPs))
 
@@ -286,28 +269,8 @@ func ListNetworkIPAvailabilities(exporter *BaseOpenStackExporter, ch chan<- prom
 	return nil
 }
 
-// ListRouters : count total number of instantiated Routers
+// ListRouters : count total number of instantiated Routers and those that are not in ACTIVE state
 func ListRouters(exporter *BaseOpenStackExporter, ch chan<- prometheus.Metric) error {
-	var allRouters []routers.Router
-
-	allPagesRouters, err := routers.List(exporter.Client, routers.ListOpts{}).AllPages()
-	if err != nil {
-		return err
-	}
-
-	allRouters, err = routers.ExtractRouters(allPagesRouters)
-	if err != nil {
-		return err
-	}
-
-	ch <- prometheus.MustNewConstMetric(exporter.Metrics["routers"].Metric,
-		prometheus.GaugeValue, float64(len(allRouters)))
-
-	return nil
-}
-
-// ListRoutersNotActive : count total number of instantiated Routers that are not in ACTIVE state
-func ListRoutersNotActive(exporter *BaseOpenStackExporter, ch chan<- prometheus.Metric) error {
 	var allRouters []routers.Router
 
 	allPagesRouters, err := routers.List(exporter.Client, routers.ListOpts{}).AllPages()
@@ -327,34 +290,16 @@ func ListRoutersNotActive(exporter *BaseOpenStackExporter, ch chan<- prometheus.
 		}
 	}
 
+	ch <- prometheus.MustNewConstMetric(exporter.Metrics["routers"].Metric,
+		prometheus.GaugeValue, float64(len(allRouters)))
 	ch <- prometheus.MustNewConstMetric(exporter.Metrics["routers_not_active"].Metric,
 		prometheus.GaugeValue, float64(failedRouters))
 
 	return nil
 }
 
-// ListLBs : count total number of instantiated LoadBalancers
+// ListLBs : count total number of instantiated LoadBalancers and those that are not in ACTIVE state
 func ListLBs(exporter *BaseOpenStackExporter, ch chan<- prometheus.Metric) error {
-	var allLBs []loadbalancers.LoadBalancer
-
-	allPagesLBs, err := loadbalancers.List(exporter.Client, loadbalancers.ListOpts{}).AllPages()
-	if err != nil {
-		return err
-	}
-
-	allLBs, err = loadbalancers.ExtractLoadBalancers(allPagesLBs)
-	if err != nil {
-		return err
-	}
-
-	ch <- prometheus.MustNewConstMetric(exporter.Metrics["loadbalancers"].Metric,
-		prometheus.GaugeValue, float64(len(allLBs)))
-
-	return nil
-}
-
-// ListLBsNotActive : count total number of instantiated LoadBalancers that are not in ACTIVE state
-func ListLBsNotActive(exporter *BaseOpenStackExporter, ch chan<- prometheus.Metric) error {
 	var allLBs []loadbalancers.LoadBalancer
 
 	allPagesLBs, err := loadbalancers.List(exporter.Client, loadbalancers.ListOpts{}).AllPages()
@@ -374,6 +319,8 @@ func ListLBsNotActive(exporter *BaseOpenStackExporter, ch chan<- prometheus.Metr
 		}
 	}
 
+	ch <- prometheus.MustNewConstMetric(exporter.Metrics["loadbalancers"].Metric,
+		prometheus.GaugeValue, float64(len(allLBs)))
 	ch <- prometheus.MustNewConstMetric(exporter.Metrics["loadbalancers_not_active"].Metric,
 		prometheus.GaugeValue, float64(failedLBs))
 

--- a/exporters/neutron.go
+++ b/exporters/neutron.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/loadbalancers"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/networkipavailabilities"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/portsbinding"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/networks"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/ports"
@@ -27,9 +28,10 @@ var defaultNeutronMetrics = []Metric{
 	{Name: "networks", Fn: ListNetworks},
 	{Name: "security_groups", Fn: ListSecGroups},
 	{Name: "subnets", Fn: ListSubnets},
-	{Name: "ports", Fn: ListPorts},
-	{Name: "ports_no_ips", Fn: ListPortsNoIPs},
-	{Name: "ports_lb_not_active", Fn: ListPortsLBsNotActive},
+	{Name: "port", Labels: []string{"uuid", "network_id", "mac_address", "device_owner", "status", "binding_vif_type"}, Fn: ListPorts},
+	{Name: "ports"},
+	{Name: "ports_no_ips"},
+	{Name: "ports_lb_not_active"},
 	{Name: "routers", Fn: ListRouters},
 	{Name: "routers_not_active", Fn: ListRoutersNotActive},
 	{Name: "agent_state", Labels: []string{"hostname", "service", "adminState"}, Fn: ListAgentStates},
@@ -193,78 +195,54 @@ func ListSubnets(exporter *BaseOpenStackExporter, ch chan<- prometheus.Metric) e
 	return nil
 }
 
-// ListPorts : count total number of instantiated Ports
+// PortBinding represents a port which includes port bindings
+type PortBinding struct {
+	ports.Port
+	portsbinding.PortsBindingExt
+}
+
+// ListPorts generates metrics about ports inside the OpenStack cloud
 func ListPorts(exporter *BaseOpenStackExporter, ch chan<- prometheus.Metric) error {
-	var allPorts []ports.Port
+	var allPorts []PortBinding
 
 	allPagesPorts, err := ports.List(exporter.Client, ports.ListOpts{}).AllPages()
 	if err != nil {
 		return err
 	}
 
-	allPorts, err = ports.ExtractPorts(allPagesPorts)
+	err = ports.ExtractPortsInto(allPagesPorts, &allPorts)
 	if err != nil {
 		return err
 	}
 
+	portsWithNoIP := float64(0)
+	lbaasPortsInactive := float64(0)
+
+	for _, port := range allPorts {
+		if port.Status == "ACTIVE" && len(port.FixedIPs) == 0 {
+			portsWithNoIP++
+		}
+
+		if port.DeviceOwner == "neutron:LOADBALANCERV2" && port.Status != "ACTIVE" {
+			lbaasPortsInactive++
+		}
+
+		ch <- prometheus.MustNewConstMetric(exporter.Metrics["port"].Metric,
+			prometheus.GaugeValue, 1, port.ID, port.NetworkID, port.MACAddress, port.DeviceOwner, port.Status, port.VIFType)
+	}
+
+	// NOTE(mnaser): We should deprecate this and users can replace it by
+	//               count(openstack_neutron_port)
 	ch <- prometheus.MustNewConstMetric(exporter.Metrics["ports"].Metric,
 		prometheus.GaugeValue, float64(len(allPorts)))
 
-	return nil
-}
-
-// ListPortsNoIPs : count total number of ACTIVE Ports with no IP
-func ListPortsNoIPs(exporter *BaseOpenStackExporter, ch chan<- prometheus.Metric) error {
-	var allPorts []ports.Port
-	var opts = ports.ListOpts{Status: "ACTIVE"}
-
-	allPagesPorts, err := ports.List(exporter.Client, opts).AllPages()
-	if err != nil {
-		return err
-	}
-
-	allPorts, err = ports.ExtractPorts(allPagesPorts)
-	if err != nil {
-		return err
-	}
-
-	failedPorts := 0
-	for _, port := range allPorts {
-		if len(port.FixedIPs) == 0 {
-			failedPorts = failedPorts + 1
-		}
-	}
+	// NOTE(mnaser): We should deprecate this and users can replace it by:
+	//               count(openstack_neutron_port{device_owner="neutron:LOADBALANCERV2",status!="ACTIVE"})
+	ch <- prometheus.MustNewConstMetric(exporter.Metrics["ports_lb_not_active"].Metric,
+		prometheus.GaugeValue, lbaasPortsInactive)
 
 	ch <- prometheus.MustNewConstMetric(exporter.Metrics["ports_no_ips"].Metric,
-		prometheus.GaugeValue, float64(failedPorts))
-
-	return nil
-}
-
-// ListPortsLBsNotActive : count total number of LB Ports that are not in ACTIVE state
-func ListPortsLBsNotActive(exporter *BaseOpenStackExporter, ch chan<- prometheus.Metric) error {
-	var allPorts []ports.Port
-	var opts = ports.ListOpts{DeviceOwner: "neutron:LOADBALANCERV2"}
-
-	allPagesPorts, err := ports.List(exporter.Client, opts).AllPages()
-	if err != nil {
-		return err
-	}
-
-	allPorts, err = ports.ExtractPorts(allPagesPorts)
-	if err != nil {
-		return err
-	}
-
-	failedPorts := 0
-	for _, port := range allPorts {
-		if port.Status != "ACTIVE" {
-			failedPorts = failedPorts + 1
-		}
-	}
-
-	ch <- prometheus.MustNewConstMetric(exporter.Metrics["ports_lb_not_active"].Metric,
-		prometheus.GaugeValue, float64(failedPorts))
+		prometheus.GaugeValue, portsWithNoIP)
 
 	return nil
 }

--- a/exporters/neutron_test.go
+++ b/exporters/neutron_test.go
@@ -46,6 +46,11 @@ openstack_neutron_network_ip_availabilities_used{cidr="fdbf:ac66:9be8::/64",ip_v
 # HELP openstack_neutron_networks networks
 # TYPE openstack_neutron_networks gauge
 openstack_neutron_networks 0
+# HELP openstack_neutron_port port
+# TYPE openstack_neutron_port gauge
+openstack_neutron_port{binding_vif_type="",device_owner="network:router_gateway",mac_address="fa:16:3e:58:42:ed",network_id="70c1db1f-b701-45bd-96e0-a313ee3430b3",status="ACTIVE",uuid="d80b1a3b-4fc1-49f3-952e-1e2ab7081d8b"} 1
+openstack_neutron_port{binding_vif_type="",device_owner="network:router_interface",mac_address="fa:16:3e:bb:3c:e4",network_id="f27aa545-cbdd-4907-b0c6-c9e8b039dcc2",status="ACTIVE",uuid="f71a6703-d6de-4be1-a91a-a570ede1d159"} 1
+openstack_neutron_port{binding_vif_type="ovs",device_owner="neutron:LOADBALANCERV2",mac_address="fa:16:3e:0b:14:fd",network_id="675c54a5-a9f3-4f5e-a0b4-e026b29c217b",status="N/A",uuid="f0b24508-eb48-4530-a38b-c042df147101"} 1
 # HELP openstack_neutron_ports ports
 # TYPE openstack_neutron_ports gauge
 openstack_neutron_ports 3


### PR DESCRIPTION

The neutron exporter seems to have a lot of "active/inactive" references
which are doing a query every single time, resulting in duplicate API
calls on very heavy operations (aka list all routers/ports in a cloud).

This PR updates testing to allow calling a URL only *once* during
tests which should eliminate these from making their way into the
code.

It also introduces a listing of all ports so a user can opt into
checking things like their binding state, which can be key in finding
issues in Neutron ports being unplugged.

This potentially generates a lot of records, but users can use
recording rules to aggregate them.