### PR TITLE
Add Ironic node state exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# OpenStack Exporter for Prometheus [![Build Status][buildstatus]][circleci] 
+# OpenStack Exporter for Prometheus [![Build Status][buildstatus]][circleci]
 
 A [OpenStack](https://openstack.org/) exporter for prometheus written in Golang using the
 [gophercloud](https://github.com/gophercloud/gophercloud) library.
@@ -78,11 +78,11 @@ usage: openstack-exporter [<flags>] <cloud>
 Flags:
   -h, --help                     Show context-sensitive help (also try --help-long and --help-man).
       --log.level="info"         Log level: [debug, info, warn, error, fatal]
-      --web.listen-address=":9180"  
+      --web.listen-address=":9180"
                                  address:port to listen on
-      --web.telemetry-path="/metrics"  
+      --web.telemetry-path="/metrics"
                                  uri path to expose metrics
-      --os-client-config="/etc/openstack/clouds.yaml"  
+      --os-client-config="/etc/openstack/clouds.yaml"
                                  Path to the cloud configuration file
       --prefix="openstack"       Prefix for metrics
       --endpoint-type="public"   openstack endpoint type to use (i.e: public, internal, admin)
@@ -92,7 +92,7 @@ Flags:
       --disable-service.compute  Disable the compute service exporter
       --disable-service.image    Disable the image service exporter
       --disable-service.volume   Disable the volume service exporter
-      --disable-service.identity  
+      --disable-service.identity
                                  Disable the identity service exporter
       --disable-service.object-store
                                  Disable the object-store service exporter
@@ -101,6 +101,8 @@ Flags:
       --disable-service.container-infra
                                  Disable the container-infra service exporter
       --disable-service.dns      Disable the dns service exporter
+      --disable-service.baremetal
+                                 Disable the baremetal service exporter
       --version                  Show application version.
 
 Args:
@@ -184,7 +186,7 @@ openstack_cinder_limits_volume_max_gb|tenant="demo-project",tenant_id="0c4e939ac
 openstack_cinder_limits_volume_used_gb|tenant="demo-project",tenant_id="0c4e939acacf4376bdcd1129f1a054ad"|40000.0 (float)
 openstack_cinder_volumes|region="RegionOne"|4.0 (float)
 openstack_cinder_snapshots|region="RegionOne"|4.0 (float)
-openstack_cinder_volume_status|region="RegionOne",bootable="true",id="173f7b48-c4c1-4e70-9acc-086b39073506",name="test-volume",size="1",status="available",tenant_id="bab7d5c60cd041a0a36f7c4b6e1dd978",volume_type="lvmdriver-1"|4.0 (float) 
+openstack_cinder_volume_status|region="RegionOne",bootable="true",id="173f7b48-c4c1-4e70-9acc-086b39073506",name="test-volume",size="1",status="available",tenant_id="bab7d5c60cd041a0a36f7c4b6e1dd978",volume_type="lvmdriver-1"|4.0 (float)
 openstack_designate_zones| region="RegionOne"|4.0 (float)
 openstack_designate_zone_status| region="RegionOne",id="a86dba58-0043-4cc6-a1bb-69d5e86f3ca3",name="example.org.",status="ACTIVE",tenant_id="4335d1f0-f793-11e2-b778-0800200c9a66",type="PRIMARY"|4.0 (float)
 openstack_designate_recordsets| region="RegionOne",tenant_id="4335d1f0-f793-11e2-b778-0800200c9a66",zone_id="a86dba58-0043-4cc6-a1bb-69d5e86f3ca3",zone_name="example.org."|4.0 (float)
@@ -194,7 +196,7 @@ openstack_identity_users|region="RegionOne"|30.0 (float)
 openstack_identity_projects|region="RegionOne"|33.0 (float)
 openstack_identity_groups|region="RegionOne"|1.0 (float)
 openstack_identity_regions|region="RegionOne"|1.0 (float)
-openstack_object_store_objects|region="RegionOne",container_name="test2"|1.0 (float) 
+openstack_object_store_objects|region="RegionOne",container_name="test2"|1.0 (float)
 openstack_metric_collect_seconds | {openstack_metric="agent_state",openstack_service="openstack_cinder"} |1.27843913| Only if --collect-metric-time is passed
 
 ## Example metrics
@@ -288,6 +290,16 @@ openstack_identity_regions{region="Region"} 1.0
 # HELP openstack_identity_users users
 # TYPE openstack_identity_users gauge
 openstack_identity_users{region="Region"} 39.0
+# HELP openstack_ironic_node node
+# TYPE openstack_ironic_node gauge
+openstack_ironic_node{console_enabled="true",id="f6965a47-324f-41fa-995e-0011333aa79e",maintenance="false",name="r1-02",power_state="power off",provision_state="available"} 1
+openstack_ironic_node{console_enabled="true",id="a016f9c9-3faf-425b-88a4-a16e4308d72d",maintenance="false",name="r1-04",power_state="power off",provision_state="available"} 1
+openstack_ironic_node{console_enabled="true",id="0fbd1d8c-2842-4d90-b1e0-43e13c195fd5",maintenance="false",name="r1-05",power_state="power off",provision_state="available"} 1
+openstack_ironic_node{console_enabled="true",id="3fc2e062-7826-46ec-8bd1-695511e30a0c",maintenance="false",name="r1-03",power_state="power off",provision_state="available"} 1
+openstack_ironic_node{console_enabled="true",id="b3d57927-206f-4eed-97a2-33069c12efa7",maintenance="false",name="r1-01",power_state="power off",provision_state="available"} 1
+# HELP openstack_ironic_up up
+# TYPE openstack_ironic_up gauge
+openstack_ironic_up 1
 # HELP openstack_neutron_agent_state agent_state
 # TYPE openstack_neutron_agent_state counter
 openstack_neutron_agent_state{adminState="up",hostname="compute-node-01",region="Region",service="neutron-dhcp-agent"} 1.0

--- a/exporters/exporter.go
+++ b/exporters/exporter.go
@@ -266,6 +266,13 @@ func NewExporter(name, prefix, cloud string, disabledMetrics []string, endpointT
 				return nil, err
 			}
 		}
+	case "baremetal":
+		{
+			exporter, err = NewIronicExporter(&exporterConfig)
+			if err != nil {
+				return nil, err
+			}
+		}
 	default:
 		{
 			return nil, fmt.Errorf("couldn't find a handler for %s exporter", name)

--- a/exporters/exporter_test.go
+++ b/exporters/exporter_test.go
@@ -81,6 +81,7 @@ var fixtures map[string]string = map[string]string{
 	"/neutron/v2.0/network-ip-availabilities":        "neutron_network_ip_availabilities",
 	"/neutron/v2.0/routers":                          "neutron_routers",
 	"/neutron/v2.0/lbaas/loadbalancers":              "neutron_loadbalancers",
+	"/ironic/nodes":                                  "ironic_nodes",
 	"/volumes":                                       "cinder_api_discovery",
 	"/volumes/volumes/detail?all_tenants=true":       "cinder_volumes",
 	"/volumes/snapshots":                             "cinder_snapshots",
@@ -153,4 +154,5 @@ func TestOpenStackSuites(t *testing.T) {
 	suite.Run(t, &GlanceTestSuite{BaseOpenStackTestSuite: BaseOpenStackTestSuite{ServiceName: "image"}})
 	suite.Run(t, &ContainerInfraTestSuite{BaseOpenStackTestSuite: BaseOpenStackTestSuite{ServiceName: "container-infra"}})
 	suite.Run(t, &DesignateTestSuite{BaseOpenStackTestSuite: BaseOpenStackTestSuite{ServiceName: "dns"}})
+	suite.Run(t, &IronicTestSuite{BaseOpenStackTestSuite: BaseOpenStackTestSuite{ServiceName: "baremetal"}})
 }

--- a/exporters/fixtures/ironic_nodes.json
+++ b/exporters/fixtures/ironic_nodes.json
@@ -1,0 +1,644 @@
+{
+  "nodes": [
+    {
+      "target_power_state": null,
+      "automated_clean": null,
+      "inspect_interface": "no-inspect",
+      "links": [
+        {
+          "href": "https://openstack.example.org:6385/v1/nodes/c9f98cc9-25e9-424e-8a89-002989054ec2",
+          "rel": "self"
+        },
+        {
+          "href": "https://openstack.example.org:6385/nodes/c9f98cc9-25e9-424e-8a89-002989054ec2",
+          "rel": "bookmark"
+        }
+      ],
+      "target_provision_state": null,
+      "deploy_step": {},
+      "storage_interface": "noop",
+      "conductor_group": "",
+      "protected_reason": null,
+      "maintenance_reason": null,
+      "states": [
+        {
+          "href": "https://openstack.example.org:6385/v1/nodes/c9f98cc9-25e9-424e-8a89-002989054ec2/states",
+          "rel": "self"
+        },
+        {
+          "href": "https://openstack.example.org:6385/nodes/c9f98cc9-25e9-424e-8a89-002989054ec2/states",
+          "rel": "bookmark"
+        }
+      ],
+      "traits": [],
+      "provision_state": "available",
+      "clean_step": {},
+      "vendor_interface": "ipmitool",
+      "description": null,
+      "uuid": "c9f98cc9-25e9-424e-8a89-002989054ec2",
+      "console_enabled": true,
+      "extra": {},
+      "raid_config": {},
+      "provision_updated_at": "2019-07-12T05:14:03+00:00",
+      "power_state": "power off",
+      "last_error": null,
+      "target_raid_config": {},
+      "network_interface": "neutron",
+      "inspection_started_at": null,
+      "inspection_finished_at": null,
+      "maintenance": true,
+      "conductor": "https://ironic01.openstack.example.org",
+      "power_interface": "ipmitool",
+      "driver": "ipmi",
+      "updated_at": "2020-06-22T17:11:51+00:00",
+      "volume": [
+        {
+          "href": "https://openstack.example.org:6385/v1/nodes/c9f98cc9-25e9-424e-8a89-002989054ec2/volume",
+          "rel": "self"
+        },
+        {
+          "href": "https://openstack.example.org:6385/nodes/c9f98cc9-25e9-424e-8a89-002989054ec2/volume",
+          "rel": "bookmark"
+        }
+      ],
+      "raid_interface": "agent",
+      "rescue_interface": "no-rescue",
+      "boot_interface": "pxe",
+      "reservation": null,
+      "management_interface": "ipmitool",
+      "properties": {
+        "memory_mb": 131072,
+        "cpu_arch": "x86_64",
+        "local_gb": 128,
+        "cpus": 48,
+        "capabilities": "boot_option:local,sw_tag:0123456,sw_port:Te1/2/1"
+      },
+      "bios_interface": "no-bios",
+      "instance_uuid": null,
+      "name": "r1-05",
+      "driver_info": {
+        "ipmi_terminal_port": 30101,
+        "ipmi_username": "root",
+        "deploy_kernel": "7ff5ef56-daaa-4256-9dd8-c3f1f9964ebc",
+        "ipmi_address": "10.10.0.101",
+        "deploy_ramdisk": "e9c96d45-a4c8-4165-8753-9d8f32779e99",
+        "ipmi_password": "******"
+      },
+      "resource_class": "baremetal",
+      "fault": null,
+      "created_at": "2015-06-08T12:04:01+00:00",
+      "portgroups": [
+        {
+          "href": "https://openstack.example.org:6385/v1/nodes/c9f98cc9-25e9-424e-8a89-002989054ec2/portgroups",
+          "rel": "self"
+        },
+        {
+          "href": "https://openstack.example.org:6385/nodes/c9f98cc9-25e9-424e-8a89-002989054ec2/portgroups",
+          "rel": "bookmark"
+        }
+      ],
+      "deploy_interface": "iscsi",
+      "ports": [
+        {
+          "href": "https://openstack.example.org:6385/v1/nodes/c9f98cc9-25e9-424e-8a89-002989054ec2/ports",
+          "rel": "self"
+        },
+        {
+          "href": "https://openstack.example.org:6385/nodes/c9f98cc9-25e9-424e-8a89-002989054ec2/ports",
+          "rel": "bookmark"
+        }
+      ],
+      "console_interface": "ipmitool-socat",
+      "protected": false,
+      "driver_internal_info": {
+        "agent_url": "http://10.0.0.27:9999",
+        "deploy_steps": null,
+        "agent_version": "3.0.0"
+      },
+      "chassis_uuid": "e502b695-a037-4613-a9ec-dd2fefa4eff5",
+      "owner": null,
+      "instance_info": {},
+      "allocation_uuid": null
+    },
+    {
+      "target_power_state": null,
+      "automated_clean": null,
+      "inspect_interface": "no-inspect",
+      "links": [
+        {
+          "href": "https://openstack.example.org:6385/v1/nodes/d5641882-f7e5-4b92-9423-7e8157586218",
+          "rel": "self"
+        },
+        {
+          "href": "https://openstack.example.org:6385/nodes/d5641882-f7e5-4b92-9423-7e8157586218",
+          "rel": "bookmark"
+        }
+      ],
+      "target_provision_state": null,
+      "deploy_step": {},
+      "storage_interface": "noop",
+      "conductor_group": "",
+      "protected_reason": null,
+      "maintenance_reason": null,
+      "states": [
+        {
+          "href": "https://openstack.example.org:6385/v1/nodes/d5641882-f7e5-4b92-9423-7e8157586218/states",
+          "rel": "self"
+        },
+        {
+          "href": "https://openstack.example.org:6385/nodes/d5641882-f7e5-4b92-9423-7e8157586218/states",
+          "rel": "bookmark"
+        }
+      ],
+      "traits": [],
+      "provision_state": "error",
+      "clean_step": {},
+      "vendor_interface": "ipmitool",
+      "description": null,
+      "uuid": "d5641882-f7e5-4b92-9423-7e8157586218",
+      "console_enabled": true,
+      "extra": {},
+      "raid_config": {},
+      "provision_updated_at": "2020-07-14T06:36:37+00:00",
+      "power_state": "power off",
+      "last_error": null,
+      "target_raid_config": {},
+      "network_interface": "neutron",
+      "inspection_started_at": null,
+      "inspection_finished_at": null,
+      "maintenance": true,
+      "conductor": "https://ironic01.openstack.example.org",
+      "power_interface": "ipmitool",
+      "driver": "ipmi",
+      "updated_at": "2020-07-14T06:36:38+00:00",
+      "volume": [
+        {
+          "href": "https://openstack.example.org:6385/v1/nodes/d5641882-f7e5-4b92-9423-7e8157586218/volume",
+          "rel": "self"
+        },
+        {
+          "href": "https://openstack.example.org:6385/nodes/d5641882-f7e5-4b92-9423-7e8157586218/volume",
+          "rel": "bookmark"
+        }
+      ],
+      "raid_interface": "agent",
+      "rescue_interface": "no-rescue",
+      "boot_interface": "pxe",
+      "reservation": null,
+      "management_interface": "ipmitool",
+      "properties": {
+        "memory_mb": 131072,
+        "cpu_arch": "x86_64",
+        "local_gb": 128,
+        "cpus": 48,
+        "capabilities": "boot_option:local,sw_tag:0123456,sw_port:Te1/2/2"
+      },
+      "bios_interface": "no-bios",
+      "instance_uuid": null,
+      "name": "r1-01",
+      "driver_info": {
+        "ipmi_terminal_port": 30102,
+        "ipmi_username": "root",
+        "deploy_kernel": "7ff5ef56-daaa-4256-9dd8-c3f1f9964ebc",
+        "ipmi_address": "10.10.0.102",
+        "deploy_ramdisk": "e9c96d45-a4c8-4165-8753-9d8f32779e99",
+        "ipmi_password": "******"
+      },
+      "resource_class": "baremetal",
+      "fault": null,
+      "created_at": "2015-06-09T09:55:01+00:00",
+      "portgroups": [
+        {
+          "href": "https://openstack.example.org:6385/v1/nodes/d5641882-f7e5-4b92-9423-7e8157586218/portgroups",
+          "rel": "self"
+        },
+        {
+          "href": "https://openstack.example.org:6385/nodes/d5641882-f7e5-4b92-9423-7e8157586218/portgroups",
+          "rel": "bookmark"
+        }
+      ],
+      "deploy_interface": "iscsi",
+      "ports": [
+        {
+          "href": "https://openstack.example.org:6385/v1/nodes/d5641882-f7e5-4b92-9423-7e8157586218/ports",
+          "rel": "self"
+        },
+        {
+          "href": "https://openstack.example.org:6385/nodes/d5641882-f7e5-4b92-9423-7e8157586218/ports",
+          "rel": "bookmark"
+        }
+      ],
+      "console_interface": "ipmitool-socat",
+      "protected": false,
+      "driver_internal_info": {
+        "agent_url": "http://10.0.0.58:9999",
+        "deploy_steps": null,
+        "agent_version": "3.0.0",
+        "last_power_state_change": "2020-07-14T06:36:20.158662",
+        "agent_last_heartbeat": "2020-07-14T06:24:43.116681"
+      },
+      "chassis_uuid": "3d3c84db-88e8-4130-b082-ed344ac09be0",
+      "owner": null,
+      "instance_info": {},
+      "allocation_uuid": null
+    },
+    {
+      "target_power_state": null,
+      "automated_clean": null,
+      "inspect_interface": "no-inspect",
+      "links": [
+        {
+          "href": "https://openstack.example.org:6385/v1/nodes/f50dcc35-4913-4667-a9fa-d130659c5661",
+          "rel": "self"
+        },
+        {
+          "href": "https://openstack.example.org:6385/nodes/f50dcc35-4913-4667-a9fa-d130659c5661",
+          "rel": "bookmark"
+        }
+      ],
+      "target_provision_state": null,
+      "deploy_step": {},
+      "storage_interface": "noop",
+      "conductor_group": "",
+      "protected_reason": null,
+      "maintenance_reason": null,
+      "states": [
+        {
+          "href": "https://openstack.example.org:6385/v1/nodes/f50dcc35-4913-4667-a9fa-d130659c5661/states",
+          "rel": "self"
+        },
+        {
+          "href": "https://openstack.example.org:6385/nodes/f50dcc35-4913-4667-a9fa-d130659c5661/states",
+          "rel": "bookmark"
+        }
+      ],
+      "traits": [],
+      "provision_state": "available",
+      "clean_step": {},
+      "vendor_interface": "ipmitool",
+      "description": null,
+      "uuid": "f50dcc35-4913-4667-a9fa-d130659c5661",
+      "console_enabled": false,
+      "extra": {
+        "hammer_error_resets": [
+          "2018-12-11T20:00:04.092302+00:00"
+        ]
+      },
+      "raid_config": {},
+      "provision_updated_at": "2020-07-14T15:28:12+00:00",
+      "power_state": "power off",
+      "last_error": null,
+      "target_raid_config": {},
+      "network_interface": "neutron",
+      "inspection_started_at": null,
+      "inspection_finished_at": null,
+      "maintenance": false,
+      "conductor": "https://ironic01.openstack.example.org",
+      "power_interface": "ipmitool",
+      "driver": "ipmi",
+      "updated_at": "2020-07-14T15:28:14+00:00",
+      "volume": [
+        {
+          "href": "https://openstack.example.org:6385/v1/nodes/f50dcc35-4913-4667-a9fa-d130659c5661/volume",
+          "rel": "self"
+        },
+        {
+          "href": "https://openstack.example.org:6385/nodes/f50dcc35-4913-4667-a9fa-d130659c5661/volume",
+          "rel": "bookmark"
+        }
+      ],
+      "raid_interface": "agent",
+      "rescue_interface": "no-rescue",
+      "boot_interface": "pxe",
+      "reservation": null,
+      "management_interface": "ipmitool",
+      "properties": {
+        "memory_mb": 131072,
+        "cpu_arch": "x86_64",
+        "local_gb": 128,
+        "cpus": 48,
+        "capabilities": "boot_option:local,sw_tag:0123456,sw_port:Te1/7/3"
+      },
+      "bios_interface": "no-bios",
+      "instance_uuid": null,
+      "name": "r1-02",
+      "driver_info": {
+        "ipmi_terminal_port": 30131,
+        "ipmi_username": "root",
+        "deploy_kernel": "7ff5ef56-daaa-4256-9dd8-c3f1f9964ebc",
+        "ipmi_address": "10.10.0.131",
+        "deploy_ramdisk": "e9c96d45-a4c8-4165-8753-9d8f32779e99",
+        "ipmi_password": "******"
+      },
+      "resource_class": "baremetal",
+      "fault": null,
+      "created_at": "2015-06-12T10:47:11+00:00",
+      "portgroups": [
+        {
+          "href": "https://openstack.example.org:6385/v1/nodes/f50dcc35-4913-4667-a9fa-d130659c5661/portgroups",
+          "rel": "self"
+        },
+        {
+          "href": "https://openstack.example.org:6385/nodes/f50dcc35-4913-4667-a9fa-d130659c5661/portgroups",
+          "rel": "bookmark"
+        }
+      ],
+      "deploy_interface": "iscsi",
+      "ports": [
+        {
+          "href": "https://openstack.example.org:6385/v1/nodes/f50dcc35-4913-4667-a9fa-d130659c5661/ports",
+          "rel": "self"
+        },
+        {
+          "href": "https://openstack.example.org:6385/nodes/f50dcc35-4913-4667-a9fa-d130659c5661/ports",
+          "rel": "bookmark"
+        }
+      ],
+      "console_interface": "ipmitool-socat",
+      "protected": false,
+      "driver_internal_info": {
+        "agent_url": "http://10.0.0.127:9999",
+        "deploy_steps": null,
+        "agent_version": "3.0.0",
+        "last_power_state_change": "2020-07-14T15:19:17.085408",
+        "agent_last_heartbeat": "2020-07-14T15:16:45.404241"
+      },
+      "chassis_uuid": "a771c716-ee9b-4aa5-bc7c-c60883d10003",
+      "owner": null,
+      "instance_info": {},
+      "allocation_uuid": null
+    },
+    {
+      "target_power_state": null,
+      "automated_clean": null,
+      "inspect_interface": "no-inspect",
+      "links": [
+        {
+          "href": "https://openstack.example.org:6385/v1/nodes/d381bea3-8768-4f12-a9b3-abf750ba918f",
+          "rel": "self"
+        },
+        {
+          "href": "https://openstack.example.org:6385/nodes/d381bea3-8768-4f12-a9b3-abf750ba918f",
+          "rel": "bookmark"
+        }
+      ],
+      "target_provision_state": null,
+      "deploy_step": {},
+      "storage_interface": "noop",
+      "conductor_group": "",
+      "protected_reason": null,
+      "maintenance_reason": null,
+      "states": [
+        {
+          "href": "https://openstack.example.org:6385/v1/nodes/d381bea3-8768-4f12-a9b3-abf750ba918f/states",
+          "rel": "self"
+        },
+        {
+          "href": "https://openstack.example.org:6385/nodes/d381bea3-8768-4f12-a9b3-abf750ba918f/states",
+          "rel": "bookmark"
+        }
+      ],
+      "traits": [],
+      "provision_state": "active",
+      "clean_step": {},
+      "vendor_interface": "ipmitool",
+      "description": null,
+      "uuid": "d381bea3-8768-4f12-a9b3-abf750ba918f",
+      "console_enabled": true,
+      "extra": {
+        "hammer_error_resets": [
+          "2018-05-10T12:38:40.803234+00:00"
+        ]
+      },
+      "raid_config": {},
+      "provision_updated_at": "2020-07-03T03:34:41+00:00",
+      "power_state": "power on",
+      "last_error": null,
+      "target_raid_config": {},
+      "network_interface": "neutron",
+      "inspection_started_at": null,
+      "inspection_finished_at": null,
+      "maintenance": false,
+      "conductor": "https://ironic01.openstack.example.org",
+      "power_interface": "ipmitool",
+      "driver": "ipmi",
+      "updated_at": "2020-07-07T22:53:58+00:00",
+      "volume": [
+        {
+          "href": "https://openstack.example.org:6385/v1/nodes/d381bea3-8768-4f12-a9b3-abf750ba918f/volume",
+          "rel": "self"
+        },
+        {
+          "href": "https://openstack.example.org:6385/nodes/d381bea3-8768-4f12-a9b3-abf750ba918f/volume",
+          "rel": "bookmark"
+        }
+      ],
+      "raid_interface": "agent",
+      "rescue_interface": "no-rescue",
+      "boot_interface": "pxe",
+      "reservation": null,
+      "management_interface": "ipmitool",
+      "properties": {
+        "memory_mb": 131072,
+        "cpu_arch": "x86_64",
+        "local_gb": 128,
+        "cpus": 48,
+        "capabilities": "boot_option:local,sw_tag:0123456,sw_port:Te1/12/1"
+      },
+      "bios_interface": "no-bios",
+      "instance_uuid": "31b5f585-104b-497a-bb72-b5376aaa089f",
+      "name": "r1-03",
+      "driver_info": {
+        "ipmi_terminal_port": 30241,
+        "ipmi_username": "root",
+        "deploy_kernel": "7ff5ef56-daaa-4256-9dd8-c3f1f9964ebc",
+        "ipmi_address": "10.10.0.183",
+        "deploy_ramdisk": "e9c96d45-a4c8-4165-8753-9d8f32779e99",
+        "ipmi_password": "******"
+      },
+      "resource_class": "baremetal",
+      "fault": null,
+      "created_at": "2015-06-12T10:47:23+00:00",
+      "portgroups": [
+        {
+          "href": "https://openstack.example.org:6385/v1/nodes/d381bea3-8768-4f12-a9b3-abf750ba918f/portgroups",
+          "rel": "self"
+        },
+        {
+          "href": "https://openstack.example.org:6385/nodes/d381bea3-8768-4f12-a9b3-abf750ba918f/portgroups",
+          "rel": "bookmark"
+        }
+      ],
+      "deploy_interface": "iscsi",
+      "ports": [
+        {
+          "href": "https://openstack.example.org:6385/v1/nodes/d381bea3-8768-4f12-a9b3-abf750ba918f/ports",
+          "rel": "self"
+        },
+        {
+          "href": "https://openstack.example.org:6385/nodes/d381bea3-8768-4f12-a9b3-abf750ba918f/ports",
+          "rel": "bookmark"
+        }
+      ],
+      "console_interface": "ipmitool-socat",
+      "protected": false,
+      "driver_internal_info": {
+        "deploy_boot_mode": "bios",
+        "last_power_state_change": "2020-07-03T03:34:25.612624",
+        "is_whole_disk_image": true,
+        "root_uuid_or_disk_id": "0x0000826d",
+        "agent_url": "http://10.0.0.118:9999",
+        "deploy_steps": null,
+        "agent_last_heartbeat": "2020-07-03T03:32:27.351216",
+        "agent_version": "3.0.0"
+      },
+      "chassis_uuid": "679d03b4-7bdb-48d3-ae19-1c29615caf7a",
+      "owner": null,
+      "instance_info": {
+        "root_gb": "20",
+        "display_name": "node-2",
+        "image_source": "e6d7dd49-3ecc-4da8-a2ba-e40ddfab7931",
+        "memory_mb": "1",
+        "vcpus": "1",
+        "local_gb": "128",
+        "swap_mb": "0",
+        "nova_host_id": "ironic01"
+      },
+      "allocation_uuid": null
+    },
+    {
+      "target_power_state": null,
+      "automated_clean": null,
+      "inspect_interface": "no-inspect",
+      "links": [
+        {
+          "href": "https://openstack.example.org:6385/v1/nodes/0129d2fc-0e5c-4b5b-a73b-01844d913957",
+          "rel": "self"
+        },
+        {
+          "href": "https://openstack.example.org:6385/nodes/0129d2fc-0e5c-4b5b-a73b-01844d913957",
+          "rel": "bookmark"
+        }
+      ],
+      "target_provision_state": null,
+      "deploy_step": {},
+      "storage_interface": "noop",
+      "conductor_group": "",
+      "protected_reason": null,
+      "maintenance_reason": null,
+      "states": [
+        {
+          "href": "https://openstack.example.org:6385/v1/nodes/0129d2fc-0e5c-4b5b-a73b-01844d913957/states",
+          "rel": "self"
+        },
+        {
+          "href": "https://openstack.example.org:6385/nodes/0129d2fc-0e5c-4b5b-a73b-01844d913957/states",
+          "rel": "bookmark"
+        }
+      ],
+      "traits": [],
+      "provision_state": "active",
+      "clean_step": {},
+      "vendor_interface": "ipmitool",
+      "description": null,
+      "uuid": "0129d2fc-0e5c-4b5b-a73b-01844d913957",
+      "console_enabled": true,
+      "extra": {},
+      "raid_config": {},
+      "provision_updated_at": "2020-06-30T19:06:51+00:00",
+      "power_state": "power on",
+      "last_error": null,
+      "target_raid_config": {},
+      "network_interface": "neutron",
+      "inspection_started_at": null,
+      "inspection_finished_at": null,
+      "maintenance": false,
+      "conductor": "https://ironic01.openstack.example.org",
+      "power_interface": "ipmitool",
+      "driver": "ipmi",
+      "updated_at": "2020-06-30T19:06:51+00:00",
+      "volume": [
+        {
+          "href": "https://openstack.example.org:6385/v1/nodes/0129d2fc-0e5c-4b5b-a73b-01844d913957/volume",
+          "rel": "self"
+        },
+        {
+          "href": "https://openstack.example.org:6385/nodes/0129d2fc-0e5c-4b5b-a73b-01844d913957/volume",
+          "rel": "bookmark"
+        }
+      ],
+      "raid_interface": "agent",
+      "rescue_interface": "no-rescue",
+      "boot_interface": "pxe",
+      "reservation": null,
+      "management_interface": "ipmitool",
+      "properties": {
+        "memory_mb": 131072,
+        "cpu_arch": "x86_64",
+        "local_gb": 128,
+        "cpus": 48,
+        "capabilities": "boot_option:local,sw_tag:0123456,sw_port:Te1/6/1"
+      },
+      "bios_interface": "no-bios",
+      "instance_uuid": "c0034f14-7937-41d5-b0f1-28d0d4e96426",
+      "name": "r1-04",
+      "driver_info": {
+        "ipmi_terminal_port": 30117,
+        "ipmi_username": "root",
+        "deploy_kernel": "7ff5ef56-daaa-4256-9dd8-c3f1f9964ebc",
+        "ipmi_address": "10.10.0.117",
+        "deploy_ramdisk": "e9c96d45-a4c8-4165-8753-9d8f32779e99",
+        "ipmi_password": "******"
+      },
+      "resource_class": "baremetal",
+      "fault": null,
+      "created_at": "2015-06-12T10:47:35+00:00",
+      "portgroups": [
+        {
+          "href": "https://openstack.example.org:6385/v1/nodes/0129d2fc-0e5c-4b5b-a73b-01844d913957/portgroups",
+          "rel": "self"
+        },
+        {
+          "href": "https://openstack.example.org:6385/nodes/0129d2fc-0e5c-4b5b-a73b-01844d913957/portgroups",
+          "rel": "bookmark"
+        }
+      ],
+      "deploy_interface": "iscsi",
+      "ports": [
+        {
+          "href": "https://openstack.example.org:6385/v1/nodes/0129d2fc-0e5c-4b5b-a73b-01844d913957/ports",
+          "rel": "self"
+        },
+        {
+          "href": "https://openstack.example.org:6385/nodes/0129d2fc-0e5c-4b5b-a73b-01844d913957/ports",
+          "rel": "bookmark"
+        }
+      ],
+      "console_interface": "ipmitool-socat",
+      "protected": false,
+      "driver_internal_info": {
+        "deploy_boot_mode": "bios",
+        "last_power_state_change": "2020-06-30T19:06:34.700536",
+        "is_whole_disk_image": true,
+        "root_uuid_or_disk_id": "0x000138af",
+        "agent_url": "http://10.0.0.153:9999",
+        "deploy_steps": null,
+        "agent_version": "3.0.0",
+        "agent_last_heartbeat": "2020-06-30T19:04:26.907887"
+      },
+      "chassis_uuid": "e7aa1abc-49b6-43ff-8e64-d1820d678107",
+      "owner": null,
+      "instance_info": {
+        "root_gb": "20",
+        "display_name": "node-1",
+        "image_source": "9845cd98-5fcb-45ef-83e2-0d348a374997",
+        "memory_mb": "1",
+        "vcpus": "1",
+        "local_gb": "128",
+        "swap_mb": "0",
+        "nova_host_id": "ironic01"
+      },
+      "allocation_uuid": null
+    }
+  ]
+}

--- a/exporters/fixtures/tokens.json
+++ b/exporters/fixtures/tokens.json
@@ -227,6 +227,34 @@
                 "type": "dns",
                 "id": "413a44234e1a4c3781d4a3c7a7e4c895",
                 "name": "dns"
+            },
+            {
+                "endpoints": [
+                    {
+                        "url": "http://test.cloud/ironic",
+                        "interface": "public",
+                        "region": "RegionOne",
+                        "region_id": "RegionOne",
+                        "id": "1c4ffe935e7643d99b55938cb12bc38d"
+                    },
+                    {
+                        "url": "http://test.cloud/ironic",
+                        "interface": "internal",
+                        "region": "RegionOne",
+                        "region_id": "RegionOne",
+                        "id": "1c4ffe935e7643d99b55938cb12bc38d"
+                    },
+                    {
+                        "url": "http://test.cloud/ironic",
+                        "interface": "admin",
+                        "region": "RegionOne",
+                        "region_id": "RegionOne",
+                        "id": "1c4ffe935e7643d99b55938cb12bc38d"
+                    }
+                ],
+                "type": "baremetal",
+                "id": "413a44234e1a4c3781d4a3c7a7e4c895",
+                "name": "ironic"
             }
         ],
         "expires_at": "2100-11-07T02:58:43.578887Z",

--- a/exporters/ironic.go
+++ b/exporters/ironic.go
@@ -1,0 +1,54 @@
+package exporters
+
+import (
+	"strconv"
+
+	"github.com/gophercloud/gophercloud/openstack/baremetal/v1/nodes"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// IronicExporter : extends BaseOpenStackExporter
+type IronicExporter struct {
+	BaseOpenStackExporter
+}
+
+var defaultIronicMetrics = []Metric{
+	{Name: "node", Labels: []string{"id", "name", "provision_state", "power_state", "maintenance", "console_enabled"}, Fn: ListNodes},
+}
+
+// NewIronicExporter : returns a pointer to IronicExporter
+func NewIronicExporter(config *ExporterConfig) (*IronicExporter, error) {
+	exporter := IronicExporter{
+		BaseOpenStackExporter{
+			Name:           "ironic",
+			ExporterConfig: *config,
+		},
+	}
+
+	for _, metric := range defaultIronicMetrics {
+		exporter.AddMetric(metric.Name, metric.Fn, metric.Labels, nil)
+	}
+
+	return &exporter, nil
+}
+
+// ListNodes : list nodes
+func ListNodes(exporter *BaseOpenStackExporter, ch chan<- prometheus.Metric) error {
+	allPagesNodes, err := nodes.List(exporter.Client, nodes.ListOpts{}).AllPages()
+	if err != nil {
+		return err
+	}
+
+	allNodes, err := nodes.ExtractNodes(allPagesNodes)
+	if err != nil {
+		return err
+	}
+
+	for _, node := range allNodes {
+		ch <- prometheus.MustNewConstMetric(exporter.Metrics["node"].Metric,
+			prometheus.GaugeValue, 1.0, node.UUID, node.Name, node.ProvisionState, node.PowerState,
+			strconv.FormatBool(node.Maintenance), strconv.FormatBool(node.ConsoleEnabled))
+	}
+
+	return nil
+}

--- a/exporters/ironic_test.go
+++ b/exporters/ironic_test.go
@@ -1,0 +1,44 @@
+package exporters
+
+import (
+	"strings"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+type IronicTestSuite struct {
+	BaseOpenStackTestSuite
+}
+
+var ironicExpectedUp = `
+# HELP openstack_ironic_node node
+# TYPE openstack_ironic_node gauge
+openstack_ironic_node{console_enabled="false",id="f50dcc35-4913-4667-a9fa-d130659c5661",maintenance="false",name="r1-02",power_state="power off",provision_state="available"} 1
+openstack_ironic_node{console_enabled="true",id="0129d2fc-0e5c-4b5b-a73b-01844d913957",maintenance="false",name="r1-04",power_state="power on",provision_state="active"} 1
+openstack_ironic_node{console_enabled="true",id="c9f98cc9-25e9-424e-8a89-002989054ec2",maintenance="true",name="r1-05",power_state="power off",provision_state="available"} 1
+openstack_ironic_node{console_enabled="true",id="d381bea3-8768-4f12-a9b3-abf750ba918f",maintenance="false",name="r1-03",power_state="power on",provision_state="active"} 1
+openstack_ironic_node{console_enabled="true",id="d5641882-f7e5-4b92-9423-7e8157586218",maintenance="true",name="r1-01",power_state="power off",provision_state="error"} 1
+# HELP openstack_ironic_up up
+# TYPE openstack_ironic_up gauge
+openstack_ironic_up 1
+`
+
+var ironicExpectedDown = `
+# HELP openstack_ironic_up up
+# TYPE openstack_ironic_up gauge
+openstack_ironic_up 0
+`
+
+func (suite *IronicTestSuite) TestIronicExporter() {
+	err := testutil.CollectAndCompare(*suite.Exporter, strings.NewReader(ironicExpectedUp))
+	assert.NoError(suite.T(), err)
+}
+
+func (suite *IronicTestSuite) TestIronicExporterWithEndpointDown() {
+	suite.teardownFixtures()
+	defer suite.installFixtures()
+
+	err := testutil.CollectAndCompare(*suite.Exporter, strings.NewReader(ironicExpectedDown))
+	assert.NoError(suite.T(), err)
+}

--- a/exporters/utils.go
+++ b/exporters/utils.go
@@ -108,6 +108,8 @@ func NewServiceClient(service string, opts *clientconfig.ClientOpts, transport *
 	endpointOpts[service] = eo
 
 	switch service {
+	case "baremetal":
+		return openstack.NewBareMetalV1(pClient, eo)
 	case "clustering":
 		return openstack.NewClusteringV1(pClient, eo)
 	case "compute":

--- a/main.go
+++ b/main.go
@@ -12,7 +12,7 @@ import (
 	"gopkg.in/alecthomas/kingpin.v2"
 )
 
-var defaultEnabledServices = []string{"network", "compute", "image", "volume", "identity", "object-store", "load-balancer", "container-infra", "dns"}
+var defaultEnabledServices = []string{"network", "compute", "image", "volume", "identity", "object-store", "load-balancer", "container-infra", "dns", "baremetal"}
 var DEFAULT_OS_CLIENT_CONFIG = "/etc/openstack/clouds.yaml"
 
 func main() {


### PR DESCRIPTION
This adds a new exporter that scrapes the state of Ironic nodes in the
deployment and returns their UUIDs, names, provision and power states,
maintenance states, and console enabled states.

This also has to add the baremetal service exporter by default, as there
is no way to explicitly enable a service that defaults to disabled. To
disable, use the --disable-service.baremetal flag.