### PR TITLE
add uuid to agent_state fields

### DIFF
--- a/exporters/cinder_test.go
+++ b/exporters/cinder_test.go
@@ -14,9 +14,9 @@ type CinderTestSuite struct {
 var cinderExpectedUp = `
 # HELP openstack_cinder_agent_state agent_state
 # TYPE openstack_cinder_agent_state counter
-openstack_cinder_agent_state{adminState="enabled",disabledReason="",hostname="devstack@lvmdriver-1",service="cinder-volume",zone="nova"} 1
-openstack_cinder_agent_state{adminState="enabled",disabledReason="Test1",hostname="devstack",service="cinder-scheduler",zone="nova"} 1
-openstack_cinder_agent_state{adminState="enabled",disabledReason="Test2",hostname="devstack",service="cinder-backup",zone="nova"} 1
+openstack_cinder_agent_state{adminState="enabled",disabledReason="",hostname="devstack@lvmdriver-1",service="cinder-volume",uuid="` + DEFAULT_UUID + `",zone="nova"} 1
+openstack_cinder_agent_state{adminState="enabled",disabledReason="Test1",hostname="devstack",service="cinder-scheduler",uuid="` + DEFAULT_UUID + `",zone="nova"} 1
+openstack_cinder_agent_state{adminState="enabled",disabledReason="Test2",hostname="devstack",service="cinder-backup",uuid="` + DEFAULT_UUID + `",zone="nova"} 1
 # HELP openstack_cinder_limits_volume_max_gb limits_volume_max_gb
 # TYPE openstack_cinder_limits_volume_max_gb gauge
 openstack_cinder_limits_volume_max_gb{tenant="admin",tenant_id="0c4e939acacf4376bdcd1129f1a054ad"} 1000

--- a/exporters/exporter.go
+++ b/exporters/exporter.go
@@ -3,6 +3,7 @@ package exporters
 import (
 	"crypto/tls"
 	"fmt"
+	"github.com/hashicorp/go-uuid"
 	"net/http"
 	"time"
 
@@ -37,8 +38,8 @@ type OpenStackExporter interface {
 	MetricIsDisabled(name string) bool
 }
 
-func EnableExporter(service, prefix, cloud string, disabledMetrics []string, endpointType string, collectTime bool) (*OpenStackExporter, error) {
-	exporter, err := NewExporter(service, prefix, cloud, disabledMetrics, endpointType, collectTime)
+func EnableExporter(service, prefix, cloud string, disabledMetrics []string, endpointType string, collectTime bool, uuidGenFunc func() (string, error)) (*OpenStackExporter, error) {
+	exporter, err := NewExporter(service, prefix, cloud, disabledMetrics, endpointType, collectTime, uuidGenFunc)
 	if err != nil {
 		return nil, err
 	}
@@ -56,6 +57,7 @@ type ExporterConfig struct {
 	Prefix          string
 	DisabledMetrics []string
 	CollectTime     bool
+	UUIDGenFunc     func() (string, error)
 }
 
 type BaseOpenStackExporter struct {
@@ -172,7 +174,7 @@ func (exporter *BaseOpenStackExporter) AddMetric(name string, fn ListFunc, label
 	}
 }
 
-func NewExporter(name, prefix, cloud string, disabledMetrics []string, endpointType string, collectTime bool) (OpenStackExporter, error) {
+func NewExporter(name, prefix, cloud string, disabledMetrics []string, endpointType string, collectTime bool, uuidGenFunc func() (string, error)) (OpenStackExporter, error) {
 	var exporter OpenStackExporter
 	var err error
 	var transport *http.Transport
@@ -195,11 +197,16 @@ func NewExporter(name, prefix, cloud string, disabledMetrics []string, endpointT
 		return nil, err
 	}
 
+	if uuidGenFunc == nil {
+		uuidGenFunc = uuid.GenerateUUID
+	}
+
 	exporterConfig := ExporterConfig{
 		Client:          client,
 		Prefix:          prefix,
 		DisabledMetrics: disabledMetrics,
 		CollectTime:     collectTime,
+		UUIDGenFunc:     uuidGenFunc,
 	}
 
 	switch name {

--- a/exporters/exporter_test.go
+++ b/exporters/exporter_test.go
@@ -99,6 +99,8 @@ var fixtures map[string]string = map[string]string{
 	"/designate/v2/zones/a86dba58-0043-4cc6-a1bb-69d5e86f3ca3/recordsets": "designate_recordsets",
 }
 
+const DEFAULT_UUID = "3649e0f6-de80-ab6e-4f1c-351042d2f7fe"
+
 func (suite *BaseOpenStackTestSuite) SetupTest() {
 	httpmock.Activate()
 	suite.Prefix = "openstack"
@@ -108,7 +110,10 @@ func (suite *BaseOpenStackTestSuite) SetupTest() {
 
 	os.Setenv("OS_CLIENT_CONFIG_FILE", path.Join(baseFixturePath, "test_config.yaml"))
 
-	exporter, err := NewExporter(suite.ServiceName, suite.Prefix, cloudName, []string{}, "public", false)
+	exporter, err := NewExporter(suite.ServiceName, suite.Prefix, cloudName, []string{}, "public", false, func() (string, error) {
+		return DEFAULT_UUID, nil
+	})
+
 	if err != nil {
 		panic(err)
 	}

--- a/exporters/fixtures/neutron_agents.json
+++ b/exporters/fixtures/neutron_agents.json
@@ -7,7 +7,7 @@
             "heartbeat_timestamp": "2017-09-12 19:40:08",
             "admin_state_up": true,
             "alive": true,
-            "id": " 04c62b91-b799-48b7-9cd5-2982db6df9c6",
+            "id": "04c62b91-b799-48b7-9cd5-2982db6df9c6",
             "topic": "N/A",
             "host": "agenthost1",
             "agent_type": "Open vSwitch agent",

--- a/exporters/neutron_test.go
+++ b/exporters/neutron_test.go
@@ -14,11 +14,11 @@ type NeutronTestSuite struct {
 var neutronExpectedUp = `
 # HELP openstack_neutron_agent_state agent_state
 # TYPE openstack_neutron_agent_state counter
-openstack_neutron_agent_state{adminState="up",hostname="agenthost1",service="neutron-dhcp-agent"} 1
-openstack_neutron_agent_state{adminState="up",hostname="agenthost1",service="neutron-l3-agent"} 1
-openstack_neutron_agent_state{adminState="up",hostname="agenthost1",service="neutron-lbaasv2-agent"} 1
-openstack_neutron_agent_state{adminState="up",hostname="agenthost1",service="neutron-metadata-agent"} 1
-openstack_neutron_agent_state{adminState="up",hostname="agenthost1",service="neutron-openvswitch-agent"} 1
+openstack_neutron_agent_state{adminState="up",hostname="agenthost1",id="840d5d68-5759-4e9e-812f-f3bd19214c7f",service="neutron-dhcp-agent"} 1
+openstack_neutron_agent_state{adminState="up",hostname="agenthost1",id="a09b81fc-5a42-46d3-a306-1a5d122a7787",service="neutron-l3-agent"} 1
+openstack_neutron_agent_state{adminState="up",hostname="agenthost1",id="2bf84eaf-d869-49cc-8401-cbbca5177e59",service="neutron-lbaasv2-agent"} 1
+openstack_neutron_agent_state{adminState="up",hostname="agenthost1",id="c876c9f7-1058-4b9b-90ed-20fb3f905ec4",service="neutron-metadata-agent"} 1
+openstack_neutron_agent_state{adminState="up",hostname="agenthost1",id="04c62b91-b799-48b7-9cd5-2982db6df9c6",service="neutron-openvswitch-agent"} 1
 # HELP openstack_neutron_floating_ips floating_ips
 # TYPE openstack_neutron_floating_ips gauge
 openstack_neutron_floating_ips 4

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.13
 require (
 	github.com/gophercloud/gophercloud v0.9.0
 	github.com/gophercloud/utils v0.0.0-20191129022341-463e26ffa30d
+	github.com/hashicorp/go-uuid v1.0.1
 	github.com/jarcoal/httpmock v1.0.4
 	github.com/kr/pretty v0.2.0 // indirect
 	github.com/prometheus/client_golang v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -31,6 +31,7 @@ github.com/gophercloud/gophercloud v0.9.0 h1:eJHQQFguQRv2FatH2d2VXH2ueTe2XzjgjwF
 github.com/gophercloud/gophercloud v0.9.0/go.mod h1:gmC5oQqMDOMO1t1gq5DquX/yAU808e/4mzjjDA76+Ss=
 github.com/gophercloud/utils v0.0.0-20191129022341-463e26ffa30d h1:lHwkWOlNjHUNDVdoOacrVD/UKqLn/xsEGyD8JBATv9Y=
 github.com/gophercloud/utils v0.0.0-20191129022341-463e26ffa30d/go.mod h1:SZ9FTKibIotDtCrxAU/evccoyu1yhKST6hgBvwTB5Eg=
+github.com/hashicorp/go-uuid v1.0.1 h1:fv1ep09latC32wFoVwnqcnKJGnMSdBanPczbHAYm1BE=
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/jarcoal/httpmock v1.0.4 h1:jp+dy/+nonJE4g4xbVtl9QdrUNbn6/3hDT5R4nDIZnA=
 github.com/jarcoal/httpmock v1.0.4/go.mod h1:ATjnClrvW/3tijVmpL/va5Z3aAyGvqU3gCT8nX0Txik=

--- a/main.go
+++ b/main.go
@@ -57,7 +57,7 @@ func main() {
 	enabledExporters := 0
 	for service, disabled := range services {
 		if !*disabled {
-			_, err := exporters.EnableExporter(service, *prefix, *cloud, *disabledMetrics, *endpointType, *collectTime)
+			_, err := exporters.EnableExporter(service, *prefix, *cloud, *disabledMetrics, *endpointType, *collectTime, nil)
 			if err != nil {
 				// Log error and continue with enabling other exporters
 				log.Errorf("enabling exporter for service %s failed: %s", service, err)


### PR DESCRIPTION
As identified on #115 if two metrics are gathered when deployed in HA
with the same labels, the collector will fail.

The only way we can circumvent this is by having a unique ID (if not provided
by the os-service API) or the ID of the service.

Signed-off-by: Jorge Niedbalski <jnr@metaklass.org>