### PR TITLE
Add openstack_identity_project_info metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ openstack_designate_recordsets_status| region="RegionOne",id="f7b10e9b-0cae-4a91
 openstack_identity_domains|region="RegionOne"|1.0 (float)
 openstack_identity_users|region="RegionOne"|30.0 (float)
 openstack_identity_projects|region="RegionOne"|33.0 (float)
+openstack_identity_project_info|is_domain="false",description="This is a project description,domain_id="default",enabled="true",id="0c4e939acacf4376bdcd1129f1a054ad",name="demo-project"|1.0 (float)
 openstack_identity_groups|region="RegionOne"|1.0 (float)
 openstack_identity_regions|region="RegionOne"|1.0 (float)
 openstack_object_store_objects|region="RegionOne",container_name="test2"|1.0 (float)
@@ -292,19 +293,32 @@ openstack_gnocchi_status_metricd_processors 8
 openstack_gnocchi_total_metrics 2759
 # HELP openstack_identity_domains domains
 # TYPE openstack_identity_domains gauge
-openstack_identity_domains{region="Region"} 1.0
+openstack_identity_domains 1
 # HELP openstack_identity_groups groups
 # TYPE openstack_identity_groups gauge
-openstack_identity_groups{region="Region"} 0.0
+openstack_identity_groups 2
+# HELP openstack_identity_project_info project_info
+# TYPE openstack_identity_project_info gauge
+openstack_identity_project_info{description="",domain_id="1bc2169ca88e4cdaaba46d4c15390b65",enabled="true",id="4b1eb781a47440acb8af9850103e537f",is_domain="false",name="swifttenanttest4"} 1
+openstack_identity_project_info{description="",domain_id="default",enabled="true",id="0c4e939acacf4376bdcd1129f1a054ad",is_domain="false",name="admin"} 1
+openstack_identity_project_info{description="",domain_id="default",enabled="true",id="2db68fed84324f29bb73130c6c2094fb",is_domain="false",name="swifttenanttest2"} 1
+openstack_identity_project_info{description="",domain_id="default",enabled="true",id="3d594eb0f04741069dbbb521635b21c7",is_domain="false",name="service"} 1
+openstack_identity_project_info{description="",domain_id="default",enabled="true",id="43ebde53fc314b1c9ea2b8c5dc744927",is_domain="false",name="swifttenanttest1"} 1
+openstack_identity_project_info{description="",domain_id="default",enabled="true",id="5961c443439d4fcebe42643723755e9d",is_domain="false",name="invisible_to_admin"} 1
+openstack_identity_project_info{description="",domain_id="default",enabled="true",id="fdb8424c4e4f4c0ba32c52e2de3bd80e",is_domain="false",name="alt_demo"} 1
+openstack_identity_project_info{description="This is a demo project.",domain_id="default",enabled="true",id="0cbd49cbf76d405d9c86562e1d579bd3",is_domain="false",name="demo"} 1
 # HELP openstack_identity_projects projects
 # TYPE openstack_identity_projects gauge
-openstack_identity_projects{region="Region"} 33.0
+openstack_identity_projects 8
 # HELP openstack_identity_regions regions
 # TYPE openstack_identity_regions gauge
-openstack_identity_regions{region="Region"} 1.0
+openstack_identity_regions 1
+# HELP openstack_identity_up up
+# TYPE openstack_identity_up gauge
+openstack_identity_up 1
 # HELP openstack_identity_users users
 # TYPE openstack_identity_users gauge
-openstack_identity_users{region="Region"} 39.0
+openstack_identity_users 2
 # HELP openstack_ironic_node node
 # TYPE openstack_ironic_node gauge
 openstack_ironic_node{console_enabled="true",id="f6965a47-324f-41fa-995e-0011333aa79e",maintenance="false",name="r1-02",power_state="power off",provision_state="available"} 1

--- a/exporters/exporter_test.go
+++ b/exporters/exporter_test.go
@@ -74,6 +74,10 @@ var fixtures map[string]string = map[string]string{
 	"/gnocchi/v1/status":                      "gnocchi_status",
 	"/gnocchi/v1/status?details=true":         "gnocchi_status",
 	"/identity/v3/projects":                   "identity_projects",
+	"/identity/v3/domains":                    "identity_domains",
+	"/identity/v3/users":                      "identity_users",
+	"/identity/v3/groups":                     "identity_groups",
+	"/identity/v3/regions":                    "identity_regions",
 	"/neutron/":                               "neutron_api_discovery",
 	"/neutron/v2.0/floatingips":               "neutron_floating_ips",
 	"/neutron/v2.0/agents":                    "neutron_agents",
@@ -166,4 +170,5 @@ func TestOpenStackSuites(t *testing.T) {
 	suite.Run(t, &DesignateTestSuite{BaseOpenStackTestSuite: BaseOpenStackTestSuite{ServiceName: "dns"}})
 	suite.Run(t, &IronicTestSuite{BaseOpenStackTestSuite: BaseOpenStackTestSuite{ServiceName: "baremetal"}})
 	suite.Run(t, &GnocchiTestSuite{BaseOpenStackTestSuite: BaseOpenStackTestSuite{ServiceName: "gnocchi"}})
+	suite.Run(t, &KeystoneTestSuite{BaseOpenStackTestSuite: BaseOpenStackTestSuite{ServiceName: "identity"}})
 }

--- a/exporters/fixtures/identity_domains.json
+++ b/exporters/fixtures/identity_domains.json
@@ -1,0 +1,18 @@
+{
+    "domains": [
+        {
+            "description": "Owns users and tenants (i.e. projects) available on Identity API v2.",
+            "enabled": true,
+            "id": "default",
+            "links": {
+                "self": "http://example.com/v3/domains/default"
+            },
+            "name": "Default"
+        }
+    ],
+    "links": {
+        "next": null,
+        "previous": null,
+        "self": "http://example.com/v3/domains"
+    }
+}

--- a/exporters/fixtures/identity_groups.json
+++ b/exporters/fixtures/identity_groups.json
@@ -1,0 +1,33 @@
+{
+    "links": {
+        "next": null,
+        "previous": null,
+        "self": "http://example.com/identity/v3/groups"
+    },
+    "groups": [
+        {
+            "domain_id": "default",
+            "id": "2844b2a08be147a08ef58317d6471f1f",
+            "description": "group for internal support users",
+            "links": {
+                "self": "http://example.com/identity/v3/groups/2844b2a08be147a08ef58317d6471f1f"
+            },
+            "name": "internal support",
+            "extra": {
+                "email": "support@localhost"
+            }
+        },
+        {
+            "domain_id": "1789d1",
+            "id": "9fe1d3",
+            "description": "group for support users",
+            "links": {
+                "self": "https://example.com/identity/v3/groups/9fe1d3"
+            },
+            "name": "support",
+            "extra": {
+                "email": "support@example.com"
+            }
+        }
+    ]
+}

--- a/exporters/fixtures/identity_projects.json
+++ b/exporters/fixtures/identity_projects.json
@@ -20,7 +20,7 @@
         },
         {
             "is_domain": false,
-            "description": null,
+            "description": "This is a demo project.",
             "domain_id": "default",
             "enabled": true,
             "id": "0cbd49cbf76d405d9c86562e1d579bd3",

--- a/exporters/fixtures/identity_regions.json
+++ b/exporters/fixtures/identity_regions.json
@@ -1,0 +1,17 @@
+{
+    "links": {
+        "next": null,
+        "previous": null,
+        "self": "http://example.com/identity/v3/regions"
+    },
+    "regions": [
+        {
+            "description": "",
+            "id": "RegionOne",
+            "links": {
+                "self": "http://example.com/identity/v3/regions/RegionOne"
+            },
+            "parent_region_id": null
+        }
+    ]
+}

--- a/exporters/fixtures/identity_users.json
+++ b/exporters/fixtures/identity_users.json
@@ -1,0 +1,39 @@
+{
+    "links": {
+        "next": null,
+        "previous": null,
+        "self": "http://example.com/identity/v3/users"
+    },
+    "users": [
+        {
+            "domain_id": "default",
+            "enabled": true,
+            "id": "2844b2a08be147a08ef58317d6471f1f",
+            "links": {
+                "self": "http://example.com/identity/v3/users/2844b2a08be147a08ef58317d6471f1f"
+            },
+            "name": "glance",
+            "password_expires_at": null,
+            "description": "some description",
+            "extra": {
+              "email": "glance@localhost"
+            }
+        },
+        {
+            "default_project_id": "263fd9",
+            "domain_id": "1789d1",
+            "enabled": true,
+            "id": "9fe1d3",
+            "links": {
+                "self": "https://example.com/identity/v3/users/9fe1d3"
+            },
+            "name": "jsmith",
+            "password_expires_at": "2016-11-06T15:32:17.000000",
+            "email": "jsmith@example.com",
+            "options": {
+                "ignore_password_expiry": true,
+                "multi_factor_auth_rules": [["password", "totp"], ["password", "custom-auth-method"]]
+            }
+        }
+    ]
+}

--- a/exporters/keystone.go
+++ b/exporters/keystone.go
@@ -1,6 +1,8 @@
 package exporters
 
 import (
+	"strconv"
+
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/domains"
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/groups"
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/projects"
@@ -18,6 +20,7 @@ var defaultKeystoneMetrics = []Metric{
 	{Name: "users", Fn: ListUsers},
 	{Name: "groups", Fn: ListGroups},
 	{Name: "projects", Fn: ListProjects},
+	{Name: "project_info", Labels: []string{"is_domain", "description", "domain_id", "enabled", "id", "name"}},
 	{Name: "regions", Fn: ListRegions},
 }
 
@@ -69,6 +72,11 @@ func ListProjects(exporter *BaseOpenStackExporter, ch chan<- prometheus.Metric) 
 
 	ch <- prometheus.MustNewConstMetric(exporter.Metrics["projects"].Metric,
 		prometheus.GaugeValue, float64(len(allProjects)))
+	for _, p := range allProjects {
+		ch <- prometheus.MustNewConstMetric(exporter.Metrics["project_info"].Metric,
+			prometheus.GaugeValue, 1.0, strconv.FormatBool(p.IsDomain),
+			p.Description, p.DomainID, strconv.FormatBool(p.Enabled), p.ID, p.Name)
+	}
 
 	return nil
 }

--- a/exporters/keystone_test.go
+++ b/exporters/keystone_test.go
@@ -1,1 +1,62 @@
 package exporters
+
+import (
+	"strings"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+type KeystoneTestSuite struct {
+	BaseOpenStackTestSuite
+}
+
+var keystoneExpectedUp = `                       
+# HELP openstack_identity_domains domains
+# TYPE openstack_identity_domains gauge
+openstack_identity_domains 1
+# HELP openstack_identity_groups groups
+# TYPE openstack_identity_groups gauge
+openstack_identity_groups 2
+# HELP openstack_identity_project_info project_info
+# TYPE openstack_identity_project_info gauge
+openstack_identity_project_info{description="",domain_id="1bc2169ca88e4cdaaba46d4c15390b65",enabled="true",id="4b1eb781a47440acb8af9850103e537f",is_domain="false",name="swifttenanttest4"} 1
+openstack_identity_project_info{description="",domain_id="default",enabled="true",id="0c4e939acacf4376bdcd1129f1a054ad",is_domain="false",name="admin"} 1
+openstack_identity_project_info{description="",domain_id="default",enabled="true",id="2db68fed84324f29bb73130c6c2094fb",is_domain="false",name="swifttenanttest2"} 1
+openstack_identity_project_info{description="",domain_id="default",enabled="true",id="3d594eb0f04741069dbbb521635b21c7",is_domain="false",name="service"} 1
+openstack_identity_project_info{description="",domain_id="default",enabled="true",id="43ebde53fc314b1c9ea2b8c5dc744927",is_domain="false",name="swifttenanttest1"} 1
+openstack_identity_project_info{description="",domain_id="default",enabled="true",id="5961c443439d4fcebe42643723755e9d",is_domain="false",name="invisible_to_admin"} 1
+openstack_identity_project_info{description="",domain_id="default",enabled="true",id="fdb8424c4e4f4c0ba32c52e2de3bd80e",is_domain="false",name="alt_demo"} 1
+openstack_identity_project_info{description="This is a demo project.",domain_id="default",enabled="true",id="0cbd49cbf76d405d9c86562e1d579bd3",is_domain="false",name="demo"} 1
+# HELP openstack_identity_projects projects
+# TYPE openstack_identity_projects gauge
+openstack_identity_projects 8
+# HELP openstack_identity_regions regions
+# TYPE openstack_identity_regions gauge
+openstack_identity_regions 1
+# HELP openstack_identity_up up
+# TYPE openstack_identity_up gauge
+openstack_identity_up 1
+# HELP openstack_identity_users users
+# TYPE openstack_identity_users gauge
+openstack_identity_users 2
+`
+
+var keystoneExpectedDown = `
+# HELP openstack_identity_up up
+# TYPE openstack_identity_up gauge
+openstack_identity_up 0
+`
+
+func (suite *KeystoneTestSuite) TestKeystoneExporter() {
+	err := testutil.CollectAndCompare(*suite.Exporter, strings.NewReader(keystoneExpectedUp))
+	assert.NoError(suite.T(), err)
+}
+
+func (suite *KeystoneTestSuite) TestKeystoneExporterWithEndpointDown() {
+	suite.teardownFixtures()
+	defer suite.installFixtures()
+
+	err := testutil.CollectAndCompare(*suite.Exporter, strings.NewReader(keystoneExpectedDown))
+	assert.NoError(suite.T(), err)
+}


### PR DESCRIPTION
This PR adds the openstack_identity_project_info to be able to retrieve various info like tenant_id/description from a metric.

It also adds testing for the keystone component