### PR TITLE
Add support for multiple clouds

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -45,7 +45,7 @@ ifeq (, $(PRE_GO_111))
 
 		ifneq (,$(wildcard vendor))
 			# Always use the local vendor/ directory to satisfy the dependencies.
-			GOOPTS := $(GOOPTS) #-mod=vendor
+			GOOPTS := $(GOOPTS) -mod=vendor
 		endif
 	endif
 else
@@ -69,12 +69,21 @@ else
 	GO_BUILD_PLATFORM ?= $(GOHOSTOS)-$(GOHOSTARCH)
 endif
 
-PROMU_VERSION ?= 0.4.0
+GOTEST := $(GO) test
+GOTEST_DIR :=
+ifneq ($(CIRCLE_JOB),)
+ifneq ($(shell which gotestsum),)
+	GOTEST_DIR := test-results
+	GOTEST := gotestsum --junitfile $(GOTEST_DIR)/unit-tests.xml --
+endif
+endif
+
+PROMU_VERSION ?= 0.7.0
 PROMU_URL     := https://github.com/prometheus/promu/releases/download/v$(PROMU_VERSION)/promu-$(PROMU_VERSION).$(GO_BUILD_PLATFORM).tar.gz
 
 GOLANGCI_LINT :=
 GOLANGCI_LINT_OPTS ?=
-GOLANGCI_LINT_VERSION ?= v1.21.0
+GOLANGCI_LINT_VERSION ?= v1.18.0
 # golangci-lint only supports linux, darwin and windows platforms on i386/amd64.
 # windows isn't included here because of the path separator being different.
 ifeq ($(GOHOSTOS),$(filter $(GOHOSTOS),linux darwin))
@@ -86,7 +95,8 @@ endif
 PREFIX                  ?= $(shell pwd)
 BIN_DIR                 ?= $(shell pwd)
 DOCKER_IMAGE_TAG        ?= $(subst /,-,$(shell git rev-parse --abbrev-ref HEAD))
-DOCKERFILE_PATH         ?= ./
+DOCKERFILE_PATH         ?= ./Dockerfile
+DOCKERBUILD_CONTEXT     ?= ./
 DOCKER_REPO             ?= prom
 
 DOCKER_ARCHS            ?= amd64
@@ -140,15 +150,29 @@ else
 	$(GO) get $(GOOPTS) -t ./...
 endif
 
+.PHONY: update-go-deps
+update-go-deps:
+	@echo ">> updating Go dependencies"
+	@for m in $$($(GO) list -mod=readonly -m -f '{{ if and (not .Indirect) (not .Main)}}{{.Path}}{{end}}' all); do \
+		$(GO) get $$m; \
+	done
+	GO111MODULE=$(GO111MODULE) $(GO) mod tidy
+ifneq (,$(wildcard vendor))
+	GO111MODULE=$(GO111MODULE) $(GO) mod vendor
+endif
+
 .PHONY: common-test-short
-common-test-short:
+common-test-short: $(GOTEST_DIR)
 	@echo ">> running short tests"
-	GO111MODULE=$(GO111MODULE) $(GO) test -short $(GOOPTS) $(pkgs)
+	GO111MODULE=$(GO111MODULE) $(GOTEST) -short $(GOOPTS) $(pkgs)
 
 .PHONY: common-test
-common-test:
+common-test: $(GOTEST_DIR)
 	@echo ">> running all tests"
-	GO111MODULE=$(GO111MODULE) $(GO) test $(test-flags) $(GOOPTS) $(pkgs)
+	GO111MODULE=$(GO111MODULE) $(GOTEST) $(test-flags) $(GOOPTS) $(pkgs)
+
+$(GOTEST_DIR):
+	@mkdir -p $@
 
 .PHONY: common-format
 common-format:
@@ -187,7 +211,6 @@ else
 ifdef GO111MODULE
 	@echo ">> running check for unused/missing packages in go.mod"
 	GO111MODULE=$(GO111MODULE) $(GO) mod tidy
-	GO111MODULE=$(GO111MODULE) $(GO) mod vendor
 ifeq (,$(wildcard vendor))
 	@git diff --exit-code -- go.sum go.mod
 else
@@ -201,7 +224,7 @@ endif
 .PHONY: common-build
 common-build: promu
 	@echo ">> building binaries"
-	GO111MODULE=$(GO111MODULE) $(PROMU) build --prefix $(PREFIX)
+	GO111MODULE=$(GO111MODULE) $(PROMU) build --prefix $(PREFIX) $(PROMU_BINARIES)
 
 .PHONY: common-tarball
 common-tarball: promu
@@ -212,19 +235,22 @@ common-tarball: promu
 common-docker: $(BUILD_DOCKER_ARCHS)
 $(BUILD_DOCKER_ARCHS): common-docker-%:
 	docker build -t "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME)-linux-$*:$(DOCKER_IMAGE_TAG)" \
+		-f $(DOCKERFILE_PATH) \
 		--build-arg ARCH="$*" \
 		--build-arg OS="linux" \
-		$(DOCKERFILE_PATH)
+		$(DOCKERBUILD_CONTEXT)
 
 .PHONY: common-docker-publish $(PUBLISH_DOCKER_ARCHS)
 common-docker-publish: $(PUBLISH_DOCKER_ARCHS)
 $(PUBLISH_DOCKER_ARCHS): common-docker-publish-%:
 	docker push "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME)-linux-$*:$(DOCKER_IMAGE_TAG)"
 
+DOCKER_MAJOR_VERSION_TAG = $(firstword $(subst ., ,$(shell cat VERSION)))
 .PHONY: common-docker-tag-latest $(TAG_DOCKER_ARCHS)
 common-docker-tag-latest: $(TAG_DOCKER_ARCHS)
 $(TAG_DOCKER_ARCHS): common-docker-tag-latest-%:
 	docker tag "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME)-linux-$*:$(DOCKER_IMAGE_TAG)" "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME)-linux-$*:latest"
+	docker tag "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME)-linux-$*:$(DOCKER_IMAGE_TAG)" "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME)-linux-$*:v$(DOCKER_MAJOR_VERSION_TAG)"
 
 .PHONY: common-docker-manifest
 common-docker-manifest:

--- a/README.md
+++ b/README.md
@@ -53,7 +53,9 @@ and must by specified with the `--os-client-config` flag.
 
 Other options as the binding address/port can by explored with the --help flag.
 
-By default the openstack\_exporter serves on port `0.0.0.0:9180` at the `/probe` URL.
+The exporter can operate in 2 modes
+- A Legacy mode (targetting one cloud) in where the openstack\_exporter serves on port `0.0.0.0:9180` at the `/metrics` URL.
+- A multi cloud mode in where the openstack\_exporter serves on port `0.0.0.0:9180` at the `/probe` URL.
 
 You can build it by yourself by cloning this repository and run:
 
@@ -89,13 +91,36 @@ Flags:
       --prefix="openstack"       Prefix for metrics
       --endpoint-type="public"   openstack endpoint type to use (i.e: public, internal, admin)
       --collect-metric-time      time spent collecting each metric
-  -d, --disable-metric= ...      multiple --disable-metric can be specified in the format: service-metric (i.e: cinder-snapshots)
       --disable-slow-metrics     disable slow metrics for performance reasons
+      --all-clouds               Toggle the multiple cloud scrapping mode under /probe?cloud=
+  -d, --disable-metric= ...      multiple --disable-metric can be specified in the format: service-metric (i.e: cinder-snapshots)
+      --disable-service.network  Disable the network service exporter
+      --disable-service.compute  Disable the compute service exporter
+      --disable-service.image    Disable the image service exporter
+      --disable-service.volume   Disable the volume service exporter
+      --disable-service.identity
+                                 Disable the identity service exporter
+      --disable-service.object-store
+                                 Disable the object-store service exporter
+      --disable-service.load-balancer
+                                 Disable the load-balancer service exporter
+      --disable-service.container-infra
+                                 Disable the container-infra service exporter
+      --disable-service.dns      Disable the dns service exporter
+      --disable-service.baremetal
+                                 Disable the baremetal service exporter
+      --disable-service.gnocchi  Disable the gnocchi service
       --version                  Show application version.
+
+Args:
+  <cloud>  name or id of the cloud to gather metrics from
 ```
 
 ### Scrape options
 
+In legacy mode cloud and metrics to be scraped are specified as argument or flags as described above.
+To select multi cloud more the -all-cloud flag need to be used
+In that case metrics and clouds are specified in the http scrape request as described below.
 Which cloud (name or id from the `clouds.yaml` file) or what services from the cloud to scrape, can be specified as the parameters to http scrape request.
 
 Query Parameter | Description

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Other options as the binding address/port can by explored with the --help flag.
 The exporter can operate in 2 modes
 - A Legacy mode (targetting one cloud) in where the openstack\_exporter serves on port `0.0.0.0:9180` at the `/metrics` URL.
 - A multi cloud mode in where the openstack\_exporter serves on port `0.0.0.0:9180` at the `/probe` URL.
+  And where `/metrics` URL is serving own exporter metrics 
 
 You can build it by yourself by cloning this repository and run:
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ make common-build
 ```
 Multi cloud mode
 ```sh
-./openstack-exporter --os-client-config /etc/openstack/clouds.yaml --all-clouds
+./openstack-exporter --os-client-config /etc/openstack/clouds.yaml --multi-cloud
 curl "http://localhost:9180/probe?cloud=region.mycludprovider.org"
 ```
 or Legacy mode
@@ -101,7 +101,7 @@ Flags:
       --endpoint-type="public"   openstack endpoint type to use (i.e: public, internal, admin)
       --collect-metric-time      time spent collecting each metric
       --disable-slow-metrics     disable slow metrics for performance reasons
-      --all-clouds               Toggle the multiple cloud scrapping mode under /probe?cloud=
+      --multi-cloud               Toggle the multiple cloud scraping mode under /probe?cloud=
   -d, --disable-metric= ...      multiple --disable-metric can be specified in the format: service-metric (i.e: cinder-snapshots)
       --disable-service.network  Disable the network service exporter
       --disable-service.compute  Disable the compute service exporter
@@ -128,7 +128,7 @@ Args:
 ### Scrape options
 
 In legacy mode cloud and metrics to be scraped are specified as argument or flags as described above.
-To select multi cloud the -all-cloud flag need to be used
+To select multi cloud the --multi-cloud flag need to be used
 In that case metrics and clouds are specified in the http scrape request as described below.
 Which cloud (name or id from the `clouds.yaml` file) or what services from the cloud to scrape, can be specified as the parameters to http scrape request.
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ and must by specified with the `--os-client-config` flag.
 Other options as the binding address/port can by explored with the --help flag.
 
 The exporter can operate in 2 modes
+
 - A Legacy mode (targetting one cloud) in where the openstack\_exporter serves on port `0.0.0.0:9180` at the `/metrics` URL.
 - A multi cloud mode in where the openstack\_exporter serves on port `0.0.0.0:9180` at the `/probe` URL.
   And where `/metrics` URL is serving own exporter metrics 
@@ -62,10 +63,17 @@ You can build it by yourself by cloning this repository and run:
 
 ```sh
 make common-build
-./openstack-exporter --os-client-config /etc/openstack/clouds.yaml
+```
+Multi cloud mode
+```sh
+./openstack-exporter --os-client-config /etc/openstack/clouds.yaml --all-clouds
 curl "http://localhost:9180/probe?cloud=region.mycludprovider.org"
 ```
-
+or Legacy mode
+```sh
+./openstack-exporter --os-client-config /etc/openstack/clouds.yaml myregion.cloud.org
+curl "http://localhost:9180/metrics" +
+```
 Or alternatively you can use the docker images, as follows (check the openstack configuration section for configuration
 details):
 
@@ -120,7 +128,7 @@ Args:
 ### Scrape options
 
 In legacy mode cloud and metrics to be scraped are specified as argument or flags as described above.
-To select multi cloud more the -all-cloud flag need to be used
+To select multi cloud the -all-cloud flag need to be used
 In that case metrics and clouds are specified in the http scrape request as described below.
 Which cloud (name or id from the `clouds.yaml` file) or what services from the cloud to scrape, can be specified as the parameters to http scrape request.
 

--- a/exporters/exporter.go
+++ b/exporters/exporter.go
@@ -6,8 +6,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/hashicorp/go-uuid"
-
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/utils/openstack/clientconfig"
 	"github.com/hashicorp/go-uuid"

--- a/exporters/exporter.go
+++ b/exporters/exporter.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/hashicorp/go-uuid"
+
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/utils/openstack/clientconfig"
 	"github.com/hashicorp/go-uuid"
@@ -44,7 +46,6 @@ func EnableExporter(service, prefix, cloud string, disabledMetrics []string, end
 	if err != nil {
 		return nil, err
 	}
-	prometheus.MustRegister(exporter)
 	return &exporter, nil
 }
 
@@ -196,6 +197,10 @@ func NewExporter(name, prefix, cloud string, disabledMetrics []string, endpointT
 		log.Infoln("SSL verification disabled on transport")
 		tlsConfig := &tls.Config{InsecureSkipVerify: true}
 		transport = &http.Transport{TLSClientConfig: tlsConfig}
+	}
+
+	if transport != nil {
+		transport.Proxy = http.ProxyFromEnvironment
 	}
 
 	client, err := NewServiceClient(name, &opts, transport, endpointType)

--- a/exporters/exporter.go
+++ b/exporters/exporter.go
@@ -90,19 +90,6 @@ func (exporter *BaseOpenStackExporter) Describe(ch chan<- *prometheus.Desc) {
 	}
 }
 
-func (exporter *BaseOpenStackExporter) AddMetricCollectTime(collectTimeSeconds float64, metricName string, ch chan<- prometheus.Metric) {
-	metricPromatheuslabels := prometheus.Labels{
-		"openstack_service": exporter.GetName(),
-		"openstack_metric":  metricName}
-	metric := prometheus.NewDesc(
-		"openstack_metric_collect_seconds",
-		"Time needed to collect metric from OpenStack API",
-		nil,
-		metricPromatheuslabels)
-	log.Debugf("Adding metric for collecting timings: %+s", metric)
-	ch <- prometheus.MustNewConstMetric(metric, prometheus.GaugeValue, collectTimeSeconds)
-}
-
 func (exporter *BaseOpenStackExporter) RunCollection(metric *PrometheusMetric, metricName string, ch chan<- prometheus.Metric) error {
 	log.Infof("Collecting metrics for exporter: %s, metric: %s", exporter.GetName(), metricName)
 	now := time.Now()
@@ -113,7 +100,7 @@ func (exporter *BaseOpenStackExporter) RunCollection(metric *PrometheusMetric, m
 
 	log.Infof("Collected metrics for exporter: %s, metric: %s", exporter.GetName(), metricName)
 	if exporter.CollectTime {
-		exporter.AddMetricCollectTime(time.Since(now).Seconds(), metricName, ch)
+		ch <- prometheus.MustNewConstMetric(exporter.Metrics["openstack_metric_collect_seconds"].Metric, prometheus.GaugeValue, time.Since(now).Seconds(), exporter.GetName(), metricName)
 	}
 	return nil
 }
@@ -160,6 +147,11 @@ func (exporter *BaseOpenStackExporter) AddMetric(name string, fn ListFunc, label
 				"up", nil, constLabels),
 			Fn: nil,
 		}
+		exporter.Metrics["openstack_metric_collect_seconds"] = &PrometheusMetric{
+			Metric: prometheus.NewDesc(
+				"openstack_metric_collect_seconds", "Time needed to collect metric from OpenStack API", []string{"openstack_service", "openstack_metric"}, nil),
+			Fn: nil,
+		}
 	}
 
 	if constLabels == nil {
@@ -195,10 +187,6 @@ func NewExporter(name, prefix, cloud string, disabledMetrics []string, endpointT
 		log.Infoln("SSL verification disabled on transport")
 		tlsConfig := &tls.Config{InsecureSkipVerify: true}
 		transport = &http.Transport{TLSClientConfig: tlsConfig}
-	}
-
-	if transport != nil {
-		transport.Proxy = http.ProxyFromEnvironment
 	}
 
 	client, err := NewServiceClient(name, &opts, transport, endpointType)

--- a/exporters/exporter.go
+++ b/exporters/exporter.go
@@ -100,7 +100,7 @@ func (exporter *BaseOpenStackExporter) RunCollection(metric *PrometheusMetric, m
 
 	log.Infof("Collected metrics for exporter: %s, metric: %s", exporter.GetName(), metricName)
 	if exporter.CollectTime {
-		ch <- prometheus.MustNewConstMetric(exporter.Metrics["openstack_metric_collect_seconds"].Metric, prometheus.GaugeValue, time.Since(now).Seconds(), exporter.GetName(), metricName)
+		ch <- prometheus.MustNewConstMetric(exporter.Metrics["openstack_metric_collect_seconds"].Metric, prometheus.GaugeValue, time.Since(now).Seconds(), metricName)
 	}
 	return nil
 }
@@ -149,7 +149,7 @@ func (exporter *BaseOpenStackExporter) AddMetric(name string, fn ListFunc, label
 		}
 		exporter.Metrics["openstack_metric_collect_seconds"] = &PrometheusMetric{
 			Metric: prometheus.NewDesc(
-				"openstack_metric_collect_seconds", "Time needed to collect metric from OpenStack API", []string{"openstack_service", "openstack_metric"}, nil),
+				"openstack_metric_collect_seconds", "Time needed to collect metric from OpenStack API", []string{"openstack_metric"}, prometheus.Labels{"openstack_service": exporter.GetName()}),
 			Fn: nil,
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -1,11 +1,13 @@
 package main
 
 import (
-	"fmt"
+	"context"
 	"net/http"
 	"os"
+	"strings"
 
 	"github.com/openstack-exporter/openstack-exporter/exporters"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/prometheus/common/log"
 	"github.com/prometheus/common/version"
@@ -16,27 +18,19 @@ var defaultEnabledServices = []string{"network", "compute", "image", "volume", "
 
 var DEFAULT_OS_CLIENT_CONFIG = "/etc/openstack/clouds.yaml"
 
+var (
+	logLevel           = kingpin.Flag("log.level", "Log level: [debug, info, warn, error, fatal]").Default("info").String()
+	bind               = kingpin.Flag("web.listen-address", "address:port to listen on").Default(":9180").String()
+	metrics            = kingpin.Flag("web.telemetry-path", "uri path to expose metrics").Default("/metrics").String()
+	osClientConfig     = kingpin.Flag("os-client-config", "Path to the cloud configuration file").Default(DEFAULT_OS_CLIENT_CONFIG).String()
+	prefix             = kingpin.Flag("prefix", "Prefix for metrics").Default("openstack").String()
+	endpointType       = kingpin.Flag("endpoint-type", "openstack endpoint type to use (i.e: public, internal, admin)").Default("public").String()
+	collectTime        = kingpin.Flag("collect-metric-time", "time spent collecting each metric").Default("false").Bool()
+	disabledMetrics    = kingpin.Flag("disable-metric", "multiple --disable-metric can be specified in the format: service-metric (i.e: cinder-snapshots)").Default("").Short('d').Strings()
+	disableSlowMetrics = kingpin.Flag("disable-slow-metrics", "disable slow metrics for performance reasons").Default("false").Bool()
+)
+
 func main() {
-	var (
-		logLevel           = kingpin.Flag("log.level", "Log level: [debug, info, warn, error, fatal]").Default("info").String()
-		bind               = kingpin.Flag("web.listen-address", "address:port to listen on").Default(":9180").String()
-		metrics            = kingpin.Flag("web.telemetry-path", "uri path to expose metrics").Default("/metrics").String()
-		osClientConfig     = kingpin.Flag("os-client-config", "Path to the cloud configuration file").Default(DEFAULT_OS_CLIENT_CONFIG).String()
-		prefix             = kingpin.Flag("prefix", "Prefix for metrics").Default("openstack").String()
-		endpointType       = kingpin.Flag("endpoint-type", "openstack endpoint type to use (i.e: public, internal, admin)").Default("public").String()
-		collectTime        = kingpin.Flag("collect-metric-time", "time spent collecting each metric").Default("false").Bool()
-		disabledMetrics    = kingpin.Flag("disable-metric", "multiple --disable-metric can be specified in the format: service-metric (i.e: cinder-snapshots)").Default("").Short('d').Strings()
-		disableSlowMetrics = kingpin.Flag("disable-slow-metrics", "disable slow metrics for performance reasons").Default("false").Bool()
-		cloud              = kingpin.Arg("cloud", "name or id of the cloud to gather metrics from").Required().String()
-	)
-
-	services := make(map[string]*bool)
-
-	for _, service := range defaultEnabledServices {
-		flagName := fmt.Sprintf("disable-service.%s", service)
-		flagHelp := fmt.Sprintf("Disable the %s service exporter", service)
-		services[service] = kingpin.Flag(flagName, flagHelp).Default().Bool()
-	}
 
 	kingpin.Version(version.Print("openstack-exporter"))
 	kingpin.HelpFlag.Short('h')
@@ -48,31 +42,11 @@ func main() {
 		os.Exit(-1)
 	}
 
-	log.Infof("Starting openstack exporter version %s for cloud: %s", version.Info(), *cloud)
 	log.Infoln("Build context", version.BuildContext())
 
 	if *osClientConfig != DEFAULT_OS_CLIENT_CONFIG {
 		log.Debugf("Setting Env var OS_CLIENT_CONFIG_FILE = %s", *osClientConfig)
 		os.Setenv("OS_CLIENT_CONFIG_FILE", *osClientConfig)
-	}
-
-	enabledExporters := 0
-	for service, disabled := range services {
-		if !*disabled {
-			_, err := exporters.EnableExporter(service, *prefix, *cloud, *disabledMetrics, *endpointType, *collectTime, *disableSlowMetrics, nil)
-			if err != nil {
-				// Log error and continue with enabling other exporters
-				log.Errorf("enabling exporter for service %s failed: %s", service, err)
-				continue
-			}
-			log.Infof("Enabled exporter for service: %s", service)
-			enabledExporters++
-		}
-	}
-
-	if enabledExporters == 0 {
-		log.Errorln("No exporter has been enabled, exiting")
-		os.Exit(-1)
 	}
 
 	http.Handle(*metrics, promhttp.Handler())
@@ -88,7 +62,64 @@ func main() {
 			log.Error(err)
 		}
 	})
+	http.HandleFunc("/probe", probeHandler)
 
 	log.Infoln("Starting HTTP server on", *bind)
 	log.Fatal(http.ListenAndServe(*bind, nil))
+}
+
+func probeHandler(w http.ResponseWriter, r *http.Request) {
+
+	ctx, cancel := context.WithCancel(r.Context())
+	defer cancel()
+	r = r.WithContext(ctx)
+
+	registry := prometheus.NewPedanticRegistry()
+
+	cloud := r.URL.Query().Get("cloud")
+	if cloud == "" {
+		http.Error(w, "'cloud' parameter is missing", http.StatusBadRequest)
+		return
+	}
+
+	services := defaultEnabledServices
+	includeServices := r.URL.Query().Get("include_services")
+	if includeServices != "" {
+		services = strings.Split(includeServices, ",")
+	}
+
+	excludeServices := strings.Split(r.URL.Query().Get("exclude_services"), ",")
+	services = removeElements(services, excludeServices)
+
+	log.Infof("Enabled services: %v", services)
+
+	for _, service := range services {
+		exp, err := exporters.EnableExporter(service, *prefix, cloud, *disabledMetrics, *endpointType, *collectTime, *disableSlowMetrics, nil)
+		if err != nil {
+			log.Errorf("enabling exporter for service %s failed: %s", service, err)
+			continue
+		}
+		registry.MustRegister(*exp)
+		log.Infof("Enabled exporter for service: %s", service)
+	}
+
+	h := promhttp.HandlerFor(registry, promhttp.HandlerOpts{})
+	h.ServeHTTP(w, r)
+}
+
+func removeElements(slice []string, drop []string) []string {
+	res := []string{}
+	for _, s := range slice {
+		keep := true
+		for _, d := range drop {
+			if s == d {
+				keep = false
+				break
+			}
+		}
+		if keep {
+			res = append(res, s)
+		}
+	}
+	return res
 }

--- a/main.go
+++ b/main.go
@@ -77,8 +77,9 @@ func main() {
 	})
 	if *allClouds {
 		http.HandleFunc("/probe", probeHandler)
+		http.Handle("/metrics", promhttp.Handler())
 	} else {
-		http.HandleFunc("/metrics", metricHandler(services))
+		http.HandleFunc(*metrics, metricHandler(services))
 	}
 
 	log.Infoln("Starting HTTP server on", *bind)


### PR DESCRIPTION
closes #139 

:warning: PR in `Draft` status currently because it breaks the `--collect-metric-time` functionality with error:
```
* collected metric openstack_metric_collect_seconds label:<name:"openstack_metric" value:"regions" > label:<name:"openstack_service" value:"openstack_identity" > gauge:<value:1.845333353 >  with unregistered descriptor Desc{fqName: "openstack_metric_collect_seconds", help: "Time needed to collect metric from OpenStack API", constLabels: {openstack_metric="regions",openstack_service="openstack_identity"}, variableLabels: []}
```