### PR TITLE
add metric free_disk_bytes for hypervisors

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ openstack_nova_flavors|region="RegionOne"|4.0 (float)
 openstack_nova_total_vms|region="RegionOne"|12.0 (float)
 openstack_nova_server_status|region="RegionOne",hostname="compute-01""id", "name", "tenant_id", "user_id", "address_ipv4",                                                                     	"address_ipv6", "host_id", "uuid", "availability_zone"|0.0 (float)
 openstack_nova_running_vms|region="RegionOne",hostname="compute-01",availability_zone="az1",aggregates="shared,ssd"|12.0 (float)
+openstack_nova_free_disk_bytes|region="RegionOne",hostname="compute-01",aggregates="shared,ssd"|1230.0 (float)
 openstack_nova_local_storage_used_bytes|region="RegionOne",hostname="compute-01",aggregates="shared,ssd"|100.0 (float)
 openstack_nova_local_storage_available_bytes|region="RegionOne",hostname="compute-01",aggregates="shared,ssd"|30.0 (float)
 openstack_nova_memory_used_bytes|region="RegionOne",hostname="compute-01",aggregates="shared,ssd"|40000.0 (float)
@@ -557,6 +558,8 @@ openstack_nova_current_workload{aggregate="",hostname="compute-node-extra-45",re
 # HELP openstack_nova_flavors flavors
 # TYPE openstack_nova_flavors gauge
 openstack_nova_flavors{region="Region"} 6.0
+# TYPE openstack_nova_free_disk_bytes gauge
+openstack_nova_free_disk_bytes{aggregates="",availability_zone="",hostname="host1"} 1.103806595072e+12
 # HELP openstack_nova_local_storage_available_bytes local_storage_available_bytes
 # TYPE openstack_nova_local_storage_available_bytes gauge
 openstack_nova_local_storage_available_bytes{aggregate="",hostname="compute-node-01",region="Region"} 1.07823006482432e+14

--- a/exporters/nova.go
+++ b/exporters/nova.go
@@ -71,6 +71,7 @@ var defaultNovaMetrics = []Metric{
 	{Name: "memory_used_bytes", Labels: []string{"hostname", "availability_zone", "aggregates"}},
 	{Name: "local_storage_available_bytes", Labels: []string{"hostname", "availability_zone", "aggregates"}},
 	{Name: "local_storage_used_bytes", Labels: []string{"hostname", "availability_zone", "aggregates"}},
+	{Name: "free_disk_bytes", Labels: []string{"hostname", "availability_zone", "aggregates"}},
 	{Name: "server_status", Labels: []string{"id", "status", "name", "tenant_id", "user_id", "address_ipv4",
 		"address_ipv6", "host_id", "hypervisor_hostname", "uuid", "availability_zone", "flavor_id"}},
 	{Name: "limits_vcpus_max", Labels: []string{"tenant", "tenant_id"}, Fn: ListComputeLimits, Slow: true},
@@ -162,7 +163,6 @@ func ListHypervisors(exporter *BaseOpenStackExporter, ch chan<- prometheus.Metri
 		if val, ok := hostToAzMap[hypervisor.Service.Host]; ok {
 			availabilityZone = val
 		}
-
 		ch <- prometheus.MustNewConstMetric(exporter.Metrics["running_vms"].Metric,
 			prometheus.GaugeValue, float64(hypervisor.RunningVMs), hypervisor.HypervisorHostname, availabilityZone, aggregatesLabel(hypervisor.Service.Host, hostToAggrMap))
 
@@ -186,6 +186,10 @@ func ListHypervisors(exporter *BaseOpenStackExporter, ch chan<- prometheus.Metri
 
 		ch <- prometheus.MustNewConstMetric(exporter.Metrics["local_storage_used_bytes"].Metric,
 			prometheus.GaugeValue, float64(hypervisor.LocalGBUsed*GIGABYTE), hypervisor.HypervisorHostname, availabilityZone, aggregatesLabel(hypervisor.Service.Host, hostToAggrMap))
+
+		ch <- prometheus.MustNewConstMetric(exporter.Metrics["free_disk_bytes"].Metric,
+			prometheus.GaugeValue, float64(hypervisor.FreeDiskGB*GIGABYTE), hypervisor.HypervisorHostname, availabilityZone, aggregatesLabel(hypervisor.Service.Host, hostToAggrMap))
+
 	}
 
 	return nil

--- a/exporters/nova_test.go
+++ b/exporters/nova_test.go
@@ -1,9 +1,10 @@
 package exporters
 
 import (
+	"strings"
+
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
-	"strings"
 )
 
 type NovaTestSuite struct {
@@ -26,6 +27,9 @@ openstack_nova_current_workload{aggregates="",availability_zone="",hostname="hos
 # HELP openstack_nova_flavors flavors
 # TYPE openstack_nova_flavors gauge
 openstack_nova_flavors 7
+# HELP openstack_nova_free_disk_bytes free_disk_bytes
+# TYPE openstack_nova_free_disk_bytes gauge
+openstack_nova_free_disk_bytes{aggregates="",availability_zone="",hostname="host1"} 1.103806595072e+12
 # HELP openstack_nova_limits_memory_max limits_memory_max
 # TYPE openstack_nova_limits_memory_max gauge
 openstack_nova_limits_memory_max{tenant="admin",tenant_id="0c4e939acacf4376bdcd1129f1a054ad"} 51200
@@ -99,7 +103,6 @@ openstack_nova_vcpus_available{aggregates="",availability_zone="",hostname="host
 # HELP openstack_nova_vcpus_used vcpus_used
 # TYPE openstack_nova_vcpus_used gauge
 openstack_nova_vcpus_used{aggregates="",availability_zone="",hostname="host1"} 0
-
 `
 
 var novaExpectedDown = `


### PR DESCRIPTION
This PR add metric openstack_nova_free_disk_bytes which useful with thin provisioning of ephemeral disks.
https://github.com/openstack-exporter/openstack-exporter/issues/142