### PR TITLE
Add limits values for instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,8 @@ limits_vcpus_max | nova
 limits_vcpus_used | nova
 limits_memory_max | nova
 limits_memory_used | nova
+limits_instances_max | nova
+limits_instances_used | nova
 limits_volume_max_gb | cinder
 limits_volume_used_gb |  cinder
 
@@ -234,6 +236,8 @@ openstack_nova_limits_vcpus_max|tenant="demo-project"|128.0 (float)
 openstack_nova_limits_vcpus_used|tenant="demo-project"|32.0 (float)
 openstack_nova_limits_memory_max|tenant="demo-project"|40000.0 (float)
 openstack_nova_limits_memory_used|tenant="demo-project"|40000.0 (float)
+openstack_nova_limits_instances_max|tenant="demo-project"|15.0 (float)
+openstack_nova_limits_instances_used|tenant="demo-project"|5.0 (float)
 openstack_cinder_service_state|hostname="compute-01",region="RegionOne",service="cinder-backup",adminState="enabled",zone="nova"|1.0 or 0 (bool)
 openstack_cinder_limits_volume_max_gb|tenant="demo-project",tenant_id="0c4e939acacf4376bdcd1129f1a054ad"|40000.0 (float)
 openstack_cinder_limits_volume_used_gb|tenant="demo-project",tenant_id="0c4e939acacf4376bdcd1129f1a054ad"|40000.0 (float)

--- a/exporters/nova.go
+++ b/exporters/nova.go
@@ -78,6 +78,8 @@ var defaultNovaMetrics = []Metric{
 	{Name: "limits_vcpus_used", Labels: []string{"tenant", "tenant_id"}, Slow: true},
 	{Name: "limits_memory_max", Labels: []string{"tenant", "tenant_id"}, Slow: true},
 	{Name: "limits_memory_used", Labels: []string{"tenant", "tenant_id"}, Slow: true},
+	{Name: "limits_instances_used", Labels: []string{"tenant", "tenant_id"}, Slow: true},
+	{Name: "limits_instances_max", Labels: []string{"tenant", "tenant_id"}, Slow: true},
 }
 
 func NewNovaExporter(config *ExporterConfig) (*NovaExporter, error) {
@@ -330,6 +332,12 @@ func ListComputeLimits(exporter *BaseOpenStackExporter, ch chan<- prometheus.Met
 
 		ch <- prometheus.MustNewConstMetric(exporter.Metrics["limits_memory_used"].Metric,
 			prometheus.GaugeValue, float64(limits.Absolute.TotalRAMUsed), p.Name, p.ID)
+
+		ch <- prometheus.MustNewConstMetric(exporter.Metrics["limits_instances_used"].Metric,
+			prometheus.GaugeValue, float64(limits.Absolute.TotalInstancesUsed), p.Name, p.ID)
+
+		ch <- prometheus.MustNewConstMetric(exporter.Metrics["limits_instances_max"].Metric,
+			prometheus.GaugeValue, float64(limits.Absolute.MaxTotalInstances), p.Name, p.ID)
 	}
 
 	return nil

--- a/exporters/nova_test.go
+++ b/exporters/nova_test.go
@@ -30,6 +30,26 @@ openstack_nova_flavors 7
 # HELP openstack_nova_free_disk_bytes free_disk_bytes
 # TYPE openstack_nova_free_disk_bytes gauge
 openstack_nova_free_disk_bytes{aggregates="",availability_zone="",hostname="host1"} 1.103806595072e+12
+# HELP openstack_nova_limits_instances_max limits_instances_max
+# TYPE openstack_nova_limits_instances_max gauge
+openstack_nova_limits_instances_max{tenant="admin",tenant_id="0c4e939acacf4376bdcd1129f1a054ad"} 10
+openstack_nova_limits_instances_max{tenant="alt_demo",tenant_id="fdb8424c4e4f4c0ba32c52e2de3bd80e"} 10
+openstack_nova_limits_instances_max{tenant="demo",tenant_id="0cbd49cbf76d405d9c86562e1d579bd3"} 10
+openstack_nova_limits_instances_max{tenant="invisible_to_admin",tenant_id="5961c443439d4fcebe42643723755e9d"} 10
+openstack_nova_limits_instances_max{tenant="service",tenant_id="3d594eb0f04741069dbbb521635b21c7"} 10
+openstack_nova_limits_instances_max{tenant="swifttenanttest1",tenant_id="43ebde53fc314b1c9ea2b8c5dc744927"} 10
+openstack_nova_limits_instances_max{tenant="swifttenanttest2",tenant_id="2db68fed84324f29bb73130c6c2094fb"} 10
+openstack_nova_limits_instances_max{tenant="swifttenanttest4",tenant_id="4b1eb781a47440acb8af9850103e537f"} 10
+# HELP openstack_nova_limits_instances_used limits_instances_used
+# TYPE openstack_nova_limits_instances_used gauge
+openstack_nova_limits_instances_used{tenant="admin",tenant_id="0c4e939acacf4376bdcd1129f1a054ad"} 0
+openstack_nova_limits_instances_used{tenant="alt_demo",tenant_id="fdb8424c4e4f4c0ba32c52e2de3bd80e"} 0
+openstack_nova_limits_instances_used{tenant="demo",tenant_id="0cbd49cbf76d405d9c86562e1d579bd3"} 0
+openstack_nova_limits_instances_used{tenant="invisible_to_admin",tenant_id="5961c443439d4fcebe42643723755e9d"} 0
+openstack_nova_limits_instances_used{tenant="service",tenant_id="3d594eb0f04741069dbbb521635b21c7"} 0
+openstack_nova_limits_instances_used{tenant="swifttenanttest1",tenant_id="43ebde53fc314b1c9ea2b8c5dc744927"} 0
+openstack_nova_limits_instances_used{tenant="swifttenanttest2",tenant_id="2db68fed84324f29bb73130c6c2094fb"} 0
+openstack_nova_limits_instances_used{tenant="swifttenanttest4",tenant_id="4b1eb781a47440acb8af9850103e537f"} 0
 # HELP openstack_nova_limits_memory_max limits_memory_max
 # TYPE openstack_nova_limits_memory_max gauge
 openstack_nova_limits_memory_max{tenant="admin",tenant_id="0c4e939acacf4376bdcd1129f1a054ad"} 51200


### PR DESCRIPTION
Hi @niedbalski ,

I'm back with another PR to add more metrics about the limits set.  The exporter already had them for vcpus and memory but I did not find them for instances.

I could also add other metrics in this PR if you'd like. (e.g.: Floating ip used).

This would be a nice addition for me as we could then monitor when a tenant gets close to its max capacity :)

Let me know if this works for you or if you'd like me to add/modify this PR.