### PR TITLE
Add UpdateAt label to nova agent_state metrics

### DIFF
--- a/exporters/nova.go
+++ b/exporters/nova.go
@@ -63,7 +63,7 @@ var defaultNovaMetrics = []Metric{
 	{Name: "availability_zones", Fn: ListAZs},
 	{Name: "security_groups", Fn: ListComputeSecGroups},
 	{Name: "total_vms", Fn: ListAllServers},
-	{Name: "agent_state", Labels: []string{"id", "hostname", "service", "adminState", "zone", "disabledReason"}, Fn: ListNovaAgentState},
+	{Name: "agent_state", Labels: []string{"id", "hostname", "service", "adminState", "zone", "disabledReason", "UpdatedAt"}, Fn: ListNovaAgentState},
 	{Name: "running_vms", Labels: []string{"hostname", "availability_zone", "aggregates"}, Fn: ListHypervisors},
 	{Name: "current_workload", Labels: []string{"hostname", "availability_zone", "aggregates"}},
 	{Name: "vcpus_available", Labels: []string{"hostname", "availability_zone", "aggregates"}},
@@ -118,7 +118,7 @@ func ListNovaAgentState(exporter *BaseOpenStackExporter, ch chan<- prometheus.Me
 			state = 1
 		}
 		ch <- prometheus.MustNewConstMetric(exporter.Metrics["agent_state"].Metric,
-			prometheus.CounterValue, float64(state), service.ID, service.Host, service.Binary, service.Status, service.Zone, service.DisabledReason)
+			prometheus.CounterValue, float64(state), service.ID, service.Host, service.Binary, service.Status, service.Zone, service.DisabledReason, service.UpdatedAt.String())
 	}
 
 	return nil

--- a/exporters/nova_test.go
+++ b/exporters/nova_test.go
@@ -14,10 +14,10 @@ type NovaTestSuite struct {
 var novaExpectedUp = `
 # HELP openstack_nova_agent_state agent_state
 # TYPE openstack_nova_agent_state counter
-openstack_nova_agent_state{adminState="disabled",disabledReason="test1",hostname="host1",id="1",service="nova-scheduler",zone="internal"} 1
-openstack_nova_agent_state{adminState="disabled",disabledReason="test2",hostname="host1",id="2",service="nova-compute",zone="nova"} 1
-openstack_nova_agent_state{adminState="disabled",disabledReason="test4",hostname="host2",id="4",service="nova-compute",zone="nova"} 0
-openstack_nova_agent_state{adminState="enabled",disabledReason="",hostname="host2",id="3",service="nova-scheduler",zone="internal"} 0
+openstack_nova_agent_state{UpdatedAt="2012-09-18 08:03:38 +0000 UTC",adminState="disabled",disabledReason="test1",hostname="host1",id="1",service="nova-scheduler",zone="internal"} 1
+openstack_nova_agent_state{UpdatedAt="2012-09-18 08:03:38 +0000 UTC",adminState="disabled",disabledReason="test2",hostname="host1",id="2",service="nova-compute",zone="nova"} 1
+openstack_nova_agent_state{UpdatedAt="2012-10-29 13:42:02 +0000 UTC",adminState="disabled",disabledReason="test4",hostname="host2",id="4",service="nova-compute",zone="nova"} 0
+openstack_nova_agent_state{UpdatedAt="2012-10-29 13:42:02 +0000 UTC",adminState="enabled",disabledReason="",hostname="host2",id="3",service="nova-scheduler",zone="internal"} 0
 # HELP openstack_nova_availability_zones availability_zones
 # TYPE openstack_nova_availability_zones gauge
 openstack_nova_availability_zones 1

--- a/exporters/nova_test.go
+++ b/exporters/nova_test.go
@@ -15,9 +15,9 @@ var novaExpectedUp = `
 # HELP openstack_nova_agent_state agent_state
 # TYPE openstack_nova_agent_state counter
 openstack_nova_agent_state{UpdatedAt="2012-09-18 08:03:38 +0000 UTC",adminState="disabled",disabledReason="test1",hostname="host1",id="1",service="nova-scheduler",zone="internal"} 1
-openstack_nova_agent_state{UpdatedAt="2012-09-18 08:03:38 +0000 UTC",adminState="disabled",disabledReason="test2",hostname="host1",id="2",service="nova-compute",zone="nova"} 1
+openstack_nova_agent_state{UpdatedAt="2012-09-19 06:55:34 +0000 UTC",adminState="disabled",disabledReason="test2",hostname="host1",id="2",service="nova-compute",zone="nova"} 1
 openstack_nova_agent_state{UpdatedAt="2012-10-29 13:42:02 +0000 UTC",adminState="disabled",disabledReason="test4",hostname="host2",id="4",service="nova-compute",zone="nova"} 0
-openstack_nova_agent_state{UpdatedAt="2012-10-29 13:42:02 +0000 UTC",adminState="enabled",disabledReason="",hostname="host2",id="3",service="nova-scheduler",zone="internal"} 0
+openstack_nova_agent_state{UpdatedAt="2012-10-29 13:42:05 +0000 UTC",adminState="enabled",disabledReason="",hostname="host2",id="3",service="nova-scheduler",zone="internal"} 0
 # HELP openstack_nova_availability_zones availability_zones
 # TYPE openstack_nova_availability_zones gauge
 openstack_nova_availability_zones 1


### PR DESCRIPTION
When nova cell enabled, we have two nova-conductor service, one is
nova-conductor and another is super nova-super-conductor, they have same
name in different databases (nova_cell0 & nova_cell1).
The only difference for the agent_state metrics is the service ID, but
service ID is actually a db seqNo, they can be same in different
tables. In our cases, we met two nova-conductors have the same label,
that will cause metrics failed to store. So add UpdateAt to identify
different nova-conductor services.