### PR TITLE
add project_id to openstack_container_infra_cluster_status

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,7 +361,7 @@ openstack_designate_zone_status{id="a86dba58-0043-4cc6-a1bb-69d5e86f3ca3",name="
 openstack_designate_zones 1
 # HELP openstack_container_infra_cluster_status cluster_status
 # TYPE openstack_container_infra_cluster_status gauge
-openstack_container_infra_cluster_status{master_count="1",name="k8s",node_count="1",stack_id="31c1ee6c-081e-4f39-9f0f-f1d87a7defa1",status="CREATE_FAILED",uuid="273c39d5-fa17-4372-b6b1-93a572de2cef"} 1
+openstack_container_infra_cluster_status{master_count="1",name="k8s",node_count="1",project_id="0cbd49cbf76d405d9c86562e1d579bd3",stack_id="31c1ee6c-081e-4f39-9f0f-f1d87a7defa1",status="CREATE_FAILED",uuid="273c39d5-fa17-4372-b6b1-93a572de2cef"} 1
 # HELP openstack_container_infra_total_clusters total_clusters
 # TYPE openstack_container_infra_total_clusters gauge
 openstack_container_infra_total_clusters 1

--- a/exporters/containerinfra.go
+++ b/exporters/containerinfra.go
@@ -42,7 +42,7 @@ type ContainerInfraExporter struct {
 
 var defaultContainerInfraMetrics = []Metric{
 	{Name: "total_clusters", Fn: ListAllClusters},
-	{Name: "cluster_status", Labels: []string{"uuid", "name", "stack_id", "status", "node_count", "master_count"}, Fn: nil},
+	{Name: "cluster_status", Labels: []string{"uuid", "name", "stack_id", "status", "node_count", "master_count", "project_id"}, Fn: nil},
 }
 
 func NewContainerInfraExporter(config *ExporterConfig) (*ContainerInfraExporter, error) {
@@ -76,7 +76,7 @@ func ListAllClusters(exporter *BaseOpenStackExporter, ch chan<- prometheus.Metri
 	for _, cluster := range allClusters {
 		ch <- prometheus.MustNewConstMetric(exporter.Metrics["cluster_status"].Metric,
 			prometheus.GaugeValue, float64(mapClusterStatus(cluster.Status)), cluster.UUID, cluster.Name,
-			cluster.StackID, cluster.Status, strconv.Itoa(cluster.NodeCount), strconv.Itoa(cluster.MasterCount))
+			cluster.StackID, cluster.Status, strconv.Itoa(cluster.NodeCount), strconv.Itoa(cluster.MasterCount), cluster.ProjectID)
 	}
 	return nil
 }

--- a/exporters/containerinfra_test.go
+++ b/exporters/containerinfra_test.go
@@ -14,7 +14,7 @@ type ContainerInfraTestSuite struct {
 var containerInfraExpectedUp = `
 # HELP openstack_container_infra_cluster_status cluster_status
 # TYPE openstack_container_infra_cluster_status gauge
-openstack_container_infra_cluster_status{master_count="1",name="k8s",node_count="1",stack_id="31c1ee6c-081e-4f39-9f0f-f1d87a7defa1",status="CREATE_FAILED",uuid="273c39d5-fa17-4372-b6b1-93a572de2cef"} 1
+openstack_container_infra_cluster_status{master_count="1",name="k8s",node_count="1",project_id="0cbd49cbf76d405d9c86562e1d579bd3",stack_id="31c1ee6c-081e-4f39-9f0f-f1d87a7defa1",status="CREATE_FAILED",uuid="273c39d5-fa17-4372-b6b1-93a572de2cef"} 1
 # HELP openstack_container_infra_total_clusters total_clusters
 # TYPE openstack_container_infra_total_clusters gauge
 openstack_container_infra_total_clusters 1

--- a/exporters/fixtures/container_infra_clusters.json
+++ b/exporters/fixtures/container_infra_clusters.json
@@ -19,7 +19,8 @@
          "master_count":1,
          "create_timeout":60,
          "node_count":1,
-         "name":"k8s"
+         "name":"k8s",
+         "project_id":"0cbd49cbf76d405d9c86562e1d579bd3"
       }
    ]
 }


### PR DESCRIPTION
project_id helps make dashboards with a filter based on projects. It is present in other metrics, so it is reasonable to have it here as well.