### PR TITLE
Flag for disabling cinder agent uuid generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Flags:
       --disable-deprecated-metrics  
                                  Disable deprecated metrics
       --disable-cinder-agent-uuid  
-                                 Disable UUID generation for Cinder agnets
+                                 Disable UUID generation for Cinder agents
       --multi-cloud              Toggle the multiple cloud scraping mode under /probe?cloud=
       --disable-service.network  Disable the network service exporter
       --disable-service.compute  Disable the compute service exporter

--- a/README.md
+++ b/README.md
@@ -100,10 +100,13 @@ Flags:
       --prefix="openstack"       Prefix for metrics
       --endpoint-type="public"   openstack endpoint type to use (i.e: public, internal, admin)
       --collect-metric-time      time spent collecting each metric
-  -d, --disable-metric= ...      multiple --disable-metric can be specified in the format: service-metric (i.e: cinder-snapshots)
+  -d, --disable-metric= ...      multiple --disable-metric can be specified in the format: service-metric (i.e:
+                                 cinder-snapshots)
       --disable-slow-metrics     Disable slow metrics for performance reasons
       --disable-deprecated-metrics  
                                  Disable deprecated metrics
+      --disable-cinder-agent-uuid  
+                                 Disable UUID generation for Cinder agnets
       --multi-cloud              Toggle the multiple cloud scraping mode under /probe?cloud=
       --disable-service.network  Disable the network service exporter
       --disable-service.compute  Disable the compute service exporter
@@ -120,10 +123,11 @@ Flags:
       --disable-service.dns      Disable the dns service exporter
       --disable-service.baremetal  
                                  Disable the baremetal service exporter
-      --disable-service.gnocchi  Disable the gnocchi service
-      --disable-service.database Disable the database service
-      --disable-service.orchestration
-                                 Disable the orchestration service
+      --disable-service.gnocchi  Disable the gnocchi service exporter
+      --disable-service.database  
+                                 Disable the database service exporter
+      --disable-service.orchestration  
+                                 Disable the orchestration service exporter
       --version                  Show application version.
 
 Args:

--- a/exporters/cinder.go
+++ b/exporters/cinder.go
@@ -2,7 +2,6 @@ package exporters
 
 import (
 	"errors"
-	"fmt"
 	"strconv"
 	"strings"
 
@@ -236,7 +235,6 @@ func ListCinderAgentState(exporter *BaseOpenStackExporter, ch chan<- prometheus.
 		if service.State == "up" {
 			state = 1
 		}
-		fmt.Println(exporter.ExporterConfig.DisableCinderAgentUUID)
 		if !exporter.ExporterConfig.DisableCinderAgentUUID {
 			if id, err = exporter.ExporterConfig.UUIDGenFunc(); err != nil {
 				return err

--- a/exporters/cinder.go
+++ b/exporters/cinder.go
@@ -2,6 +2,7 @@ package exporters
 
 import (
 	"errors"
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -235,8 +236,11 @@ func ListCinderAgentState(exporter *BaseOpenStackExporter, ch chan<- prometheus.
 		if service.State == "up" {
 			state = 1
 		}
-		if id, err = exporter.ExporterConfig.UUIDGenFunc(); err != nil {
-			return err
+		fmt.Println(exporter.ExporterConfig.DisableCinderAgentUUID)
+		if !exporter.ExporterConfig.DisableCinderAgentUUID {
+			if id, err = exporter.ExporterConfig.UUIDGenFunc(); err != nil {
+				return err
+			}
 		}
 
 		ch <- prometheus.MustNewConstMetric(exporter.Metrics["agent_state"].Metric,

--- a/exporters/exporter.go
+++ b/exporters/exporter.go
@@ -40,8 +40,8 @@ type OpenStackExporter interface {
 	MetricIsDisabled(name string) bool
 }
 
-func EnableExporter(service, prefix, cloud string, disabledMetrics []string, endpointType string, collectTime bool, disableSlowMetrics bool, disableDeprecatedMetrics bool, uuidGenFunc func() (string, error)) (*OpenStackExporter, error) {
-	exporter, err := NewExporter(service, prefix, cloud, disabledMetrics, endpointType, collectTime, disableSlowMetrics, disableDeprecatedMetrics, uuidGenFunc)
+func EnableExporter(service, prefix, cloud string, disabledMetrics []string, endpointType string, collectTime bool, disableSlowMetrics bool, disableDeprecatedMetrics bool, disableCinderAgentUUID bool, uuidGenFunc func() (string, error)) (*OpenStackExporter, error) {
+	exporter, err := NewExporter(service, prefix, cloud, disabledMetrics, endpointType, collectTime, disableSlowMetrics, disableDeprecatedMetrics, disableCinderAgentUUID, uuidGenFunc)
 	if err != nil {
 		return nil, err
 	}
@@ -61,6 +61,7 @@ type ExporterConfig struct {
 	UUIDGenFunc              func() (string, error)
 	DisableSlowMetrics       bool
 	DisableDeprecatedMetrics bool
+	DisableCinderAgentUUID   bool
 }
 
 type BaseOpenStackExporter struct {
@@ -184,7 +185,7 @@ func (exporter *BaseOpenStackExporter) AddMetric(name string, fn ListFunc, label
 	}
 }
 
-func NewExporter(name, prefix, cloud string, disabledMetrics []string, endpointType string, collectTime bool, disableSlowMetrics bool, disableDeprecatedMetrics bool, uuidGenFunc func() (string, error)) (OpenStackExporter, error) {
+func NewExporter(name, prefix, cloud string, disabledMetrics []string, endpointType string, collectTime bool, disableSlowMetrics bool, disableDeprecatedMetrics bool, disableCinderAgentUUID bool, uuidGenFunc func() (string, error)) (OpenStackExporter, error) {
 	var exporter OpenStackExporter
 	var err error
 	var transport *http.Transport
@@ -219,6 +220,7 @@ func NewExporter(name, prefix, cloud string, disabledMetrics []string, endpointT
 		UUIDGenFunc:              uuidGenFunc,
 		DisableSlowMetrics:       disableSlowMetrics,
 		DisableDeprecatedMetrics: disableDeprecatedMetrics,
+		DisableCinderAgentUUID:   disableCinderAgentUUID,
 	}
 
 	switch name {

--- a/exporters/exporter_test.go
+++ b/exporters/exporter_test.go
@@ -128,7 +128,7 @@ func (suite *BaseOpenStackTestSuite) SetupTest() {
 
 	os.Setenv("OS_CLIENT_CONFIG_FILE", path.Join(baseFixturePath, "test_config.yaml"))
 
-	exporter, err := NewExporter(suite.ServiceName, suite.Prefix, cloudName, []string{}, "public", false, false, false, func() (string, error) {
+	exporter, err := NewExporter(suite.ServiceName, suite.Prefix, cloudName, []string{}, "public", false, false, false, false, func() (string, error) {
 		return DEFAULT_UUID, nil
 	})
 

--- a/main.go
+++ b/main.go
@@ -31,7 +31,7 @@ var (
 	disabledMetrics          = kingpin.Flag("disable-metric", "multiple --disable-metric can be specified in the format: service-metric (i.e: cinder-snapshots)").Default("").Short('d').Strings()
 	disableSlowMetrics       = kingpin.Flag("disable-slow-metrics", "Disable slow metrics for performance reasons").Default("false").Bool()
 	disableDeprecatedMetrics = kingpin.Flag("disable-deprecated-metrics", "Disable deprecated metrics").Default("false").Bool()
-	disableCinderAgentUUID   = kingpin.Flag("disable-cinder-agent-uuid", "Disable UUID generation for Cinder agnets").Default("false").Bool()
+	disableCinderAgentUUID   = kingpin.Flag("disable-cinder-agent-uuid", "Disable UUID generation for Cinder agents").Default("false").Bool()
 	cloud                    = kingpin.Arg("cloud", "name or id of the cloud to gather metrics from").String()
 	multiCloud               = kingpin.Flag("multi-cloud", "Toggle the multiple cloud scraping mode under /probe?cloud=").Default("false").Bool()
 )

--- a/main.go
+++ b/main.go
@@ -31,6 +31,7 @@ var (
 	disabledMetrics          = kingpin.Flag("disable-metric", "multiple --disable-metric can be specified in the format: service-metric (i.e: cinder-snapshots)").Default("").Short('d').Strings()
 	disableSlowMetrics       = kingpin.Flag("disable-slow-metrics", "Disable slow metrics for performance reasons").Default("false").Bool()
 	disableDeprecatedMetrics = kingpin.Flag("disable-deprecated-metrics", "Disable deprecated metrics").Default("false").Bool()
+	disableCinderAgentUUID   = kingpin.Flag("disable-cinder-agent-uuid", "Disable UUID generation for Cinder agnets").Default("false").Bool()
 	cloud                    = kingpin.Arg("cloud", "name or id of the cloud to gather metrics from").String()
 	multiCloud               = kingpin.Flag("multi-cloud", "Toggle the multiple cloud scraping mode under /probe?cloud=").Default("false").Bool()
 )
@@ -129,7 +130,7 @@ func probeHandler(services map[string]*bool) http.HandlerFunc {
 		log.Infof("Enabled services: %v", enabledServices)
 
 		for _, service := range enabledServices {
-			exp, err := exporters.EnableExporter(service, *prefix, cloud, *disabledMetrics, *endpointType, *collectTime, *disableSlowMetrics, *disableDeprecatedMetrics, nil)
+			exp, err := exporters.EnableExporter(service, *prefix, cloud, *disabledMetrics, *endpointType, *collectTime, *disableSlowMetrics, *disableDeprecatedMetrics, *disableCinderAgentUUID, nil)
 			if err != nil {
 				log.Errorf("enabling exporter for service %s failed: %s", service, err)
 				continue
@@ -157,7 +158,7 @@ func metricHandler(services map[string]*bool) http.HandlerFunc {
 		enabledExporters := 0
 		for service, disabled := range services {
 			if !*disabled {
-				exp, err := exporters.EnableExporter(service, *prefix, *cloud, *disabledMetrics, *endpointType, *collectTime, *disableSlowMetrics, *disableDeprecatedMetrics, nil)
+				exp, err := exporters.EnableExporter(service, *prefix, *cloud, *disabledMetrics, *endpointType, *collectTime, *disableSlowMetrics, *disableDeprecatedMetrics, *disableCinderAgentUUID, nil)
 				if err != nil {
 					// Log error and continue with enabling other exporters
 					log.Errorf("enabling exporter for service %s failed: %s", service, err)


### PR DESCRIPTION
This PR add flag for disabling cinder agent uuid generation.

It should fix https://github.com/openstack-exporter/openstack-exporter/issues/190