### PR TITLE
add cluster_masters and cluster_nodes metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,9 @@ openstack_identity_project_info|is_domain="false",description="This is a project
 openstack_identity_groups|region="RegionOne"|1.0 (float)
 openstack_identity_regions|region="RegionOne"|1.0 (float)
 openstack_object_store_objects|region="RegionOne",container_name="test2"|1.0 (float)
+openstack_container_infra_cluster_masters|name="k8s",node_count="1",project_id="0cbd49cbf76d405d9c86562e1d579bd3",stack_id="31c1ee6c-081e-4f39-9f0f-f1d87a7defa1",status="CREATE_FAILED",uuid="273c39d5-fa17-4372-b6b1-93a572de2cef"|1 (float)
+openstack_container_infra_cluster_nodes|master_count="1",name="k8s",project_id="0cbd49cbf76d405d9c86562e1d579bd3",stack_id="31c1ee6c-081e-4f39-9f0f-f1d87a7defa1",status="CREATE_FAILED",uuid="273c39d5-fa17-4372-b6b1-93a572de2cef"|1 (float)
+openstack_container_infra_cluster_status|master_count="1",name="k8s",node_count="1",project_id="0cbd49cbf76d405d9c86562e1d579bd3",stack_id="31c1ee6c-081e-4f39-9f0f-f1d87a7defa1",status="CREATE_FAILED",uuid="273c39d5-fa17-4372-b6b1-93a572de2cef"|1 (float)
 openstack_trove_instance_status|datastore_type="mysql",datastore_version="5.7",health_status="available",id="0cef87c6-bd23-4f6b-8458-a393c39486d8",name="mysql1",region="RegionOne",status="ACTIVE",tenant_id="0cbd49cbf76d405d9c86562e1d579bd3"|2 (float)
 openstack_trove_instance_volume_size_gb|datastore_type="mysql",datastore_version="5.7",health_status="available",id="0cef87c6-bd23-4f6b-8458-a393c39486d8",name="mysql1",region="RegionOne",status="ACTIVE",tenant_id="0cbd49cbf76d405d9c86562e1d579bd3"|20 (float)
 openstack_trove_instance_volume_used_gb|datastore_type="mysql",datastore_version="5.7",health_status="available",id="0cef87c6-bd23-4f6b-8458-a393c39486d8",name="mysql1",region="RegionOne",status="ACTIVE",tenant_id="0cbd49cbf76d405d9c86562e1d579bd3"|0.4 (float)
@@ -383,12 +386,21 @@ openstack_designate_zone_status{id="a86dba58-0043-4cc6-a1bb-69d5e86f3ca3",name="
 # HELP openstack_designate_zones zones
 # TYPE openstack_designate_zones gauge
 openstack_designate_zones 1
+# HELP openstack_container_infra_cluster_masters cluster_masters
+# TYPE openstack_container_infra_cluster_masters gauge
+openstack_container_infra_cluster_masters{name="k8s",node_count="1",project_id="0cbd49cbf76d405d9c86562e1d579bd3",stack_id="31c1ee6c-081e-4f39-9f0f-f1d87a7defa1",status="CREATE_FAILED",uuid="273c39d5-fa17-4372-b6b1-93a572de2cef"} 1
+# HELP openstack_container_infra_cluster_nodes cluster_nodes
+# TYPE openstack_container_infra_cluster_nodes gauge
+openstack_container_infra_cluster_nodes{master_count="1",name="k8s",project_id="0cbd49cbf76d405d9c86562e1d579bd3",stack_id="31c1ee6c-081e-4f39-9f0f-f1d87a7defa1",status="CREATE_FAILED",uuid="273c39d5-fa17-4372-b6b1-93a572de2cef"} 1
 # HELP openstack_container_infra_cluster_status cluster_status
 # TYPE openstack_container_infra_cluster_status gauge
 openstack_container_infra_cluster_status{master_count="1",name="k8s",node_count="1",project_id="0cbd49cbf76d405d9c86562e1d579bd3",stack_id="31c1ee6c-081e-4f39-9f0f-f1d87a7defa1",status="CREATE_FAILED",uuid="273c39d5-fa17-4372-b6b1-93a572de2cef"} 1
 # HELP openstack_container_infra_total_clusters total_clusters
 # TYPE openstack_container_infra_total_clusters gauge
 openstack_container_infra_total_clusters 1
+# HELP openstack_container_infra_up up
+# TYPE openstack_container_infra_up gauge
+openstack_container_infra_up 1
 # HELP openstack_glance_images images
 # TYPE openstack_glance_images gauge
 openstack_glance_images{region="Region"} 18.0

--- a/exporters/containerinfra.go
+++ b/exporters/containerinfra.go
@@ -43,6 +43,8 @@ type ContainerInfraExporter struct {
 
 var defaultContainerInfraMetrics = []Metric{
 	{Name: "total_clusters", Fn: ListAllClusters},
+	{Name: "cluster_masters", Labels: []string{"uuid", "name", "stack_id", "status", "node_count", "project_id"}, Fn: nil},
+	{Name: "cluster_nodes", Labels: []string{"uuid", "name", "stack_id", "status", "master_count", "project_id"}, Fn: nil},
 	{Name: "cluster_status", Labels: []string{"uuid", "name", "stack_id", "status", "node_count", "master_count", "project_id"}, Fn: nil},
 }
 
@@ -78,6 +80,12 @@ func ListAllClusters(exporter *BaseOpenStackExporter, ch chan<- prometheus.Metri
 		prometheus.GaugeValue, float64(len(allClusters)))
 	// Cluster status metrics
 	for _, cluster := range allClusters {
+		ch <- prometheus.MustNewConstMetric(exporter.Metrics["cluster_masters"].Metric,
+			prometheus.GaugeValue, float64(cluster.MasterCount), cluster.UUID, cluster.Name,
+			cluster.StackID, cluster.Status, strconv.Itoa(cluster.NodeCount), cluster.ProjectID)
+		ch <- prometheus.MustNewConstMetric(exporter.Metrics["cluster_nodes"].Metric,
+			prometheus.GaugeValue, float64(cluster.NodeCount), cluster.UUID, cluster.Name,
+			cluster.StackID, cluster.Status, strconv.Itoa(cluster.MasterCount), cluster.ProjectID)
 		ch <- prometheus.MustNewConstMetric(exporter.Metrics["cluster_status"].Metric,
 			prometheus.GaugeValue, float64(mapClusterStatus(cluster.Status)), cluster.UUID, cluster.Name,
 			cluster.StackID, cluster.Status, strconv.Itoa(cluster.NodeCount), strconv.Itoa(cluster.MasterCount), cluster.ProjectID)

--- a/exporters/containerinfra_test.go
+++ b/exporters/containerinfra_test.go
@@ -12,6 +12,12 @@ type ContainerInfraTestSuite struct {
 }
 
 var containerInfraExpectedUp = `
+# HELP openstack_container_infra_cluster_masters cluster_masters
+# TYPE openstack_container_infra_cluster_masters gauge
+openstack_container_infra_cluster_masters{name="k8s",node_count="1",project_id="0cbd49cbf76d405d9c86562e1d579bd3",stack_id="31c1ee6c-081e-4f39-9f0f-f1d87a7defa1",status="CREATE_FAILED",uuid="273c39d5-fa17-4372-b6b1-93a572de2cef"} 1
+# HELP openstack_container_infra_cluster_nodes cluster_nodes
+# TYPE openstack_container_infra_cluster_nodes gauge
+openstack_container_infra_cluster_nodes{master_count="1",name="k8s",project_id="0cbd49cbf76d405d9c86562e1d579bd3",stack_id="31c1ee6c-081e-4f39-9f0f-f1d87a7defa1",status="CREATE_FAILED",uuid="273c39d5-fa17-4372-b6b1-93a572de2cef"} 1
 # HELP openstack_container_infra_cluster_status cluster_status
 # TYPE openstack_container_infra_cluster_status gauge
 openstack_container_infra_cluster_status{master_count="1",name="k8s",node_count="1",project_id="0cbd49cbf76d405d9c86562e1d579bd3",stack_id="31c1ee6c-081e-4f39-9f0f-f1d87a7defa1",status="CREATE_FAILED",uuid="273c39d5-fa17-4372-b6b1-93a572de2cef"} 1


### PR DESCRIPTION
I suggest adding cluster_masters and cluster_nodes metrics to `container_infra` exporter to keep track of k8s masters and nodes.