### PR TITLE
Nova microversion from env

### DIFF
--- a/exporters/nova.go
+++ b/exporters/nova.go
@@ -3,6 +3,7 @@ package exporters
 import (
 	"errors"
 	"fmt"
+	"os"
 	"sort"
 
 	"github.com/gophercloud/gophercloud"
@@ -100,9 +101,16 @@ func NewNovaExporter(config *ExporterConfig) (*NovaExporter, error) {
 			exporter.AddMetric(metric.Name, metric.Fn, metric.Labels, metric.DeprecatedVersion, nil)
 		}
 	}
-	microversion, err := apiversions.Get(config.Client, "v2.1").Extract()
-	if err == nil {
-		exporter.Client.Microversion = microversion.Version
+
+	envMicroversion, present := os.LookupEnv("OS_COMPUTE_API_VERSION")
+	if present {
+		exporter.Client.Microversion = envMicroversion
+	} else {
+
+		microversion, err := apiversions.Get(config.Client, "v2.1").Extract()
+		if err == nil {
+			exporter.Client.Microversion = microversion.Version
+		}
 	}
 
 	return &exporter, nil


### PR DESCRIPTION
In https://github.com/openstack-exporter/openstack-exporter/issues/191 metrics disappeared because in new microversion fields have been removed from answer. 

But all services support min and max microversions, it is mean that even on Wallaby possible use microversion 2.87.
We have to provide posibility set microversion for exporter. 

This PR check OS_COMPUTE_API_VERSION and set it as microversion. If it does not exist exporter will use max microversion from Nova API. 