### PR TITLE
Add parent_id field to keystone project_info

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ openstack_designate_recordsets_status| region="RegionOne",id="f7b10e9b-0cae-4a91
 openstack_identity_domains|region="RegionOne"|1.0 (float)
 openstack_identity_users|region="RegionOne"|30.0 (float)
 openstack_identity_projects|region="RegionOne"|33.0 (float)
-openstack_identity_project_info|is_domain="false",description="This is a project description,domain_id="default",enabled="true",id="0c4e939acacf4376bdcd1129f1a054ad",name="demo-project"|1.0 (float)
+openstack_identity_project_info|is_domain="false",description="This is a project description,domain_id="default",enabled="true",id="0c4e939acacf4376bdcd1129f1a054ad",name="demo-project",parent_id=""|1.0 (float)
 openstack_identity_groups|region="RegionOne"|1.0 (float)
 openstack_identity_regions|region="RegionOne"|1.0 (float)
 openstack_object_store_objects|region="RegionOne",container_name="test2"|1.0 (float)
@@ -430,14 +430,14 @@ openstack_identity_domains 1
 openstack_identity_groups 2
 # HELP openstack_identity_project_info project_info
 # TYPE openstack_identity_project_info gauge
-openstack_identity_project_info{description="",domain_id="1bc2169ca88e4cdaaba46d4c15390b65",enabled="true",id="4b1eb781a47440acb8af9850103e537f",is_domain="false",name="swifttenanttest4"} 1
-openstack_identity_project_info{description="",domain_id="default",enabled="true",id="0c4e939acacf4376bdcd1129f1a054ad",is_domain="false",name="admin"} 1
-openstack_identity_project_info{description="",domain_id="default",enabled="true",id="2db68fed84324f29bb73130c6c2094fb",is_domain="false",name="swifttenanttest2"} 1
-openstack_identity_project_info{description="",domain_id="default",enabled="true",id="3d594eb0f04741069dbbb521635b21c7",is_domain="false",name="service"} 1
-openstack_identity_project_info{description="",domain_id="default",enabled="true",id="43ebde53fc314b1c9ea2b8c5dc744927",is_domain="false",name="swifttenanttest1"} 1
-openstack_identity_project_info{description="",domain_id="default",enabled="true",id="5961c443439d4fcebe42643723755e9d",is_domain="false",name="invisible_to_admin"} 1
-openstack_identity_project_info{description="",domain_id="default",enabled="true",id="fdb8424c4e4f4c0ba32c52e2de3bd80e",is_domain="false",name="alt_demo"} 1
-openstack_identity_project_info{description="This is a demo project.",domain_id="default",enabled="true",id="0cbd49cbf76d405d9c86562e1d579bd3",is_domain="false",name="demo"} 1
+openstack_identity_project_info{description="",domain_id="1bc2169ca88e4cdaaba46d4c15390b65",enabled="true",id="4b1eb781a47440acb8af9850103e537f",is_domain="false",name="swifttenanttest4",parent_id=""} 1
+openstack_identity_project_info{description="",domain_id="default",enabled="true",id="0c4e939acacf4376bdcd1129f1a054ad",is_domain="false",name="admin",parent_id=""} 1
+openstack_identity_project_info{description="",domain_id="default",enabled="true",id="2db68fed84324f29bb73130c6c2094fb",is_domain="false",name="swifttenanttest2",parent_id=""} 1
+openstack_identity_project_info{description="",domain_id="default",enabled="true",id="3d594eb0f04741069dbbb521635b21c7",is_domain="false",name="service",parent_id=""} 1
+openstack_identity_project_info{description="",domain_id="default",enabled="true",id="43ebde53fc314b1c9ea2b8c5dc744927",is_domain="false",name="swifttenanttest1",parent_id=""} 1
+openstack_identity_project_info{description="",domain_id="default",enabled="true",id="5961c443439d4fcebe42643723755e9d",is_domain="false",name="invisible_to_admin",parent_id=""} 1
+openstack_identity_project_info{description="",domain_id="default",enabled="true",id="fdb8424c4e4f4c0ba32c52e2de3bd80e",is_domain="false",name="alt_demo",parent_id=""} 1
+openstack_identity_project_info{description="This is a demo project.",domain_id="default",enabled="true",id="0cbd49cbf76d405d9c86562e1d579bd3",is_domain="false",name="demo",parent_id=""} 1
 # HELP openstack_identity_projects projects
 # TYPE openstack_identity_projects gauge
 openstack_identity_projects 8

--- a/exporters/keystone.go
+++ b/exporters/keystone.go
@@ -20,7 +20,7 @@ var defaultKeystoneMetrics = []Metric{
 	{Name: "users", Fn: ListUsers},
 	{Name: "groups", Fn: ListGroups},
 	{Name: "projects", Fn: ListProjects},
-	{Name: "project_info", Labels: []string{"is_domain", "description", "domain_id", "enabled", "id", "name"}},
+	{Name: "project_info", Labels: []string{"is_domain", "description", "domain_id", "enabled", "id", "name", "parent_id"}},
 	{Name: "regions", Fn: ListRegions},
 }
 
@@ -80,7 +80,8 @@ func ListProjects(exporter *BaseOpenStackExporter, ch chan<- prometheus.Metric) 
 	for _, p := range allProjects {
 		ch <- prometheus.MustNewConstMetric(exporter.Metrics["project_info"].Metric,
 			prometheus.GaugeValue, 1.0, strconv.FormatBool(p.IsDomain),
-			p.Description, p.DomainID, strconv.FormatBool(p.Enabled), p.ID, p.Name)
+			p.Description, p.DomainID, strconv.FormatBool(p.Enabled), p.ID, p.Name,
+			p.ParentID)
 	}
 
 	return nil

--- a/exporters/keystone_test.go
+++ b/exporters/keystone_test.go
@@ -20,14 +20,14 @@ openstack_identity_domains 1
 openstack_identity_groups 2
 # HELP openstack_identity_project_info project_info
 # TYPE openstack_identity_project_info gauge
-openstack_identity_project_info{description="",domain_id="1bc2169ca88e4cdaaba46d4c15390b65",enabled="true",id="4b1eb781a47440acb8af9850103e537f",is_domain="false",name="swifttenanttest4"} 1
-openstack_identity_project_info{description="",domain_id="default",enabled="true",id="0c4e939acacf4376bdcd1129f1a054ad",is_domain="false",name="admin"} 1
-openstack_identity_project_info{description="",domain_id="default",enabled="true",id="2db68fed84324f29bb73130c6c2094fb",is_domain="false",name="swifttenanttest2"} 1
-openstack_identity_project_info{description="",domain_id="default",enabled="true",id="3d594eb0f04741069dbbb521635b21c7",is_domain="false",name="service"} 1
-openstack_identity_project_info{description="",domain_id="default",enabled="true",id="43ebde53fc314b1c9ea2b8c5dc744927",is_domain="false",name="swifttenanttest1"} 1
-openstack_identity_project_info{description="",domain_id="default",enabled="true",id="5961c443439d4fcebe42643723755e9d",is_domain="false",name="invisible_to_admin"} 1
-openstack_identity_project_info{description="",domain_id="default",enabled="true",id="fdb8424c4e4f4c0ba32c52e2de3bd80e",is_domain="false",name="alt_demo"} 1
-openstack_identity_project_info{description="This is a demo project.",domain_id="default",enabled="true",id="0cbd49cbf76d405d9c86562e1d579bd3",is_domain="false",name="demo"} 1
+openstack_identity_project_info{description="",domain_id="1bc2169ca88e4cdaaba46d4c15390b65",enabled="true",id="4b1eb781a47440acb8af9850103e537f",is_domain="false",name="swifttenanttest4",parent_id=""} 1
+openstack_identity_project_info{description="",domain_id="default",enabled="true",id="0c4e939acacf4376bdcd1129f1a054ad",is_domain="false",name="admin",parent_id=""} 1
+openstack_identity_project_info{description="",domain_id="default",enabled="true",id="2db68fed84324f29bb73130c6c2094fb",is_domain="false",name="swifttenanttest2",parent_id=""} 1
+openstack_identity_project_info{description="",domain_id="default",enabled="true",id="3d594eb0f04741069dbbb521635b21c7",is_domain="false",name="service",parent_id=""} 1
+openstack_identity_project_info{description="",domain_id="default",enabled="true",id="43ebde53fc314b1c9ea2b8c5dc744927",is_domain="false",name="swifttenanttest1",parent_id=""} 1
+openstack_identity_project_info{description="",domain_id="default",enabled="true",id="5961c443439d4fcebe42643723755e9d",is_domain="false",name="invisible_to_admin",parent_id=""} 1
+openstack_identity_project_info{description="",domain_id="default",enabled="true",id="fdb8424c4e4f4c0ba32c52e2de3bd80e",is_domain="false",name="alt_demo",parent_id=""} 1
+openstack_identity_project_info{description="This is a demo project.",domain_id="default",enabled="true",id="0cbd49cbf76d405d9c86562e1d579bd3",is_domain="false",name="demo",parent_id=""} 1
 # HELP openstack_identity_projects projects
 # TYPE openstack_identity_projects gauge
 openstack_identity_projects 8


### PR DESCRIPTION
This can be useful in deployments using hierarchical multitenancy (nested projects).