### PR TITLE
Add openstack_glance_image_bytes metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,8 @@ openstack_cinder_volume_status | 1.4 | 1.5 | deprecated in favor of openstack_ci
 
 Name     | Sample Labels | Sample Value | Description
 ---------|---------------|--------------|------------
+openstack_glance_image_bytes|id="1bea47ed-f6a9-463b-b423-14b9cca9ad27",name="cirros-0.3.2-x86_64-disk",tenant_id="5ef70662f8b34079a6eddb8da9d75fe8"|1.3167616e+07 (float)
+openstack_glance_images|region="Region"|1.0 (float)
 openstack_neutron_agent_state|adminState="up",availability_zone="nova",hostname="compute-01",region="RegionOne",service="neutron-dhcp-agent"|1 or 0 (bool)
 openstack_neutron_floating_ip|region="RegionOne",floating_ip_address="172.24.4.227",floating_network_id="1c93472c-4d8a-11ea-92e9-08002759fd91",id="231facca-4d8a-11ea-a143-08002759fd91",project_id="0042b7564d8a11eabc2d08002759fd91",router_id="",status="DOWN"|4.0 (float)
 openstack_neutron_floating_ips|region="RegionOne"|4.0 (float)
@@ -410,6 +412,10 @@ openstack_container_infra_total_clusters 1
 # HELP openstack_container_infra_up up
 # TYPE openstack_container_infra_up gauge
 openstack_container_infra_up 1
+# HELP openstack_glance_image_bytes image_bytes
+# TYPE openstack_glance_image_bytes gauge
+openstack_glance_image_bytes{id="781b3762-9469-4cec-b58d-3349e5de4e9c",name="F17-x86_64-cfntools",tenant_id="5ef70662f8b34079a6eddb8da9d75fe8"} 4.76704768e+08
+openstack_glance_image_bytes{id="1bea47ed-f6a9-463b-b423-14b9cca9ad27",name="cirros-0.3.2-x86_64-disk",tenant_id="5ef70662f8b34079a6eddb8da9d75fe8"} 1.3167616e+07
 # HELP openstack_glance_images images
 # TYPE openstack_glance_images gauge
 openstack_glance_images{region="Region"} 18.0

--- a/exporters/glance.go
+++ b/exporters/glance.go
@@ -11,6 +11,7 @@ type GlanceExporter struct {
 
 var defaultGlanceMetrics = []Metric{
 	{Name: "images", Fn: ListImages},
+	{Name: "image_bytes", Labels: []string{"id", "name", "tenant_id"}, Fn: nil, Slow: true},
 }
 
 func NewGlanceExporter(config *ExporterConfig) (*GlanceExporter, error) {
@@ -47,6 +48,13 @@ func ListImages(exporter *BaseOpenStackExporter, ch chan<- prometheus.Metric) er
 
 	ch <- prometheus.MustNewConstMetric(exporter.Metrics["images"].Metric,
 		prometheus.GaugeValue, float64(len(allImages)))
+
+	// Image size metrics
+	for _, image := range allImages {
+		ch <- prometheus.MustNewConstMetric(exporter.Metrics["image_bytes"].Metric,
+			prometheus.GaugeValue, float64(image.SizeBytes), image.ID, image.Name,
+			image.Owner)
+	}
 
 	return nil
 }

--- a/exporters/glance_test.go
+++ b/exporters/glance_test.go
@@ -12,6 +12,10 @@ type GlanceTestSuite struct {
 }
 
 var glanceExpectedUp = `
+# HELP openstack_glance_image_bytes image_bytes
+# TYPE openstack_glance_image_bytes gauge
+openstack_glance_image_bytes{id="781b3762-9469-4cec-b58d-3349e5de4e9c",name="F17-x86_64-cfntools",tenant_id="5ef70662f8b34079a6eddb8da9d75fe8"} 4.76704768e+08
+openstack_glance_image_bytes{id="1bea47ed-f6a9-463b-b423-14b9cca9ad27",name="cirros-0.3.2-x86_64-disk",tenant_id="5ef70662f8b34079a6eddb8da9d75fe8"} 1.3167616e+07
 # HELP openstack_glance_images images
 # TYPE openstack_glance_images gauge
 openstack_glance_images 2


### PR DESCRIPTION
This metric reports the size of each image in bytes. It is marked as a slow metric because it includes image ID, image name and tenant ID as labels for each image.