### PR TITLE
Restrict metrics for a given domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Flags:
       --disable-cinder-agent-uuid  
                                  Disable UUID generation for Cinder agents
       --multi-cloud              Toggle the multiple cloud scraping mode under /probe?cloud=
+      --domain-id=DOMAIN-ID      Gather metrics only for the given Domain ID (defaults to all domains)
       --disable-service.network  Disable the network service exporter
       --disable-service.compute  Disable the compute service exporter
       --disable-service.image    Disable the image service exporter
@@ -188,6 +189,32 @@ clouds:
             ---- BEGIN CERTIFICATE ---
       ...
     verify: true | false  // disable || enable SSL certificate verification
+```
+
+### OpenStack Domain filtering
+
+The exporter provides the flag `--domain-id`, this restricts some metrics to a specific domain.
+
+*Restricting domain scope can improve scrape time, especially if you use Heat a lot.*
+
+The following metrics are filtered for the domain ID provided (the others remain the same):
+
+```
+# Cinder
+openstack_cinder_limits_volume_max_gb
+openstack_cinder_limits_volume_used_gb
+
+# Keystone
+openstack_identity_projects
+openstack_identity_project_info
+
+# Nova
+openstack_nova_limits_vcpus_max
+openstack_nova_limits_vcpus_used
+openstack_nova_limits_memory_max
+openstack_nova_limits_memory_used
+openstack_nova_limits_instances_max
+openstack_nova_limits_instances_used
 ```
 
 ## Contributing

--- a/exporters/cinder.go
+++ b/exporters/cinder.go
@@ -292,7 +292,7 @@ func ListVolumeLimits(exporter *BaseOpenStackExporter, ch chan<- prometheus.Metr
 		return err
 	}
 
-	allPagesProject, err := projects.List(c, projects.ListOpts{}).AllPages()
+	allPagesProject, err := projects.List(c, projects.ListOpts{DomainID: exporter.DomainID}).AllPages()
 	if err != nil {
 		return err
 	}

--- a/exporters/exporter.go
+++ b/exporters/exporter.go
@@ -40,8 +40,8 @@ type OpenStackExporter interface {
 	MetricIsDisabled(name string) bool
 }
 
-func EnableExporter(service, prefix, cloud string, disabledMetrics []string, endpointType string, collectTime bool, disableSlowMetrics bool, disableDeprecatedMetrics bool, disableCinderAgentUUID bool, uuidGenFunc func() (string, error)) (*OpenStackExporter, error) {
-	exporter, err := NewExporter(service, prefix, cloud, disabledMetrics, endpointType, collectTime, disableSlowMetrics, disableDeprecatedMetrics, disableCinderAgentUUID, uuidGenFunc)
+func EnableExporter(service, prefix, cloud string, disabledMetrics []string, endpointType string, collectTime bool, disableSlowMetrics bool, disableDeprecatedMetrics bool, disableCinderAgentUUID bool, domainID string, uuidGenFunc func() (string, error)) (*OpenStackExporter, error) {
+	exporter, err := NewExporter(service, prefix, cloud, disabledMetrics, endpointType, collectTime, disableSlowMetrics, disableDeprecatedMetrics, disableCinderAgentUUID, domainID, uuidGenFunc)
 	if err != nil {
 		return nil, err
 	}
@@ -62,6 +62,7 @@ type ExporterConfig struct {
 	DisableSlowMetrics       bool
 	DisableDeprecatedMetrics bool
 	DisableCinderAgentUUID   bool
+	DomainID                 string
 }
 
 type BaseOpenStackExporter struct {
@@ -185,7 +186,7 @@ func (exporter *BaseOpenStackExporter) AddMetric(name string, fn ListFunc, label
 	}
 }
 
-func NewExporter(name, prefix, cloud string, disabledMetrics []string, endpointType string, collectTime bool, disableSlowMetrics bool, disableDeprecatedMetrics bool, disableCinderAgentUUID bool, uuidGenFunc func() (string, error)) (OpenStackExporter, error) {
+func NewExporter(name, prefix, cloud string, disabledMetrics []string, endpointType string, collectTime bool, disableSlowMetrics bool, disableDeprecatedMetrics bool, disableCinderAgentUUID bool, domainID string, uuidGenFunc func() (string, error)) (OpenStackExporter, error) {
 	var exporter OpenStackExporter
 	var err error
 	var transport *http.Transport
@@ -221,6 +222,7 @@ func NewExporter(name, prefix, cloud string, disabledMetrics []string, endpointT
 		DisableSlowMetrics:       disableSlowMetrics,
 		DisableDeprecatedMetrics: disableDeprecatedMetrics,
 		DisableCinderAgentUUID:   disableCinderAgentUUID,
+		DomainID:                 domainID,
 	}
 
 	switch name {

--- a/exporters/exporter_test.go
+++ b/exporters/exporter_test.go
@@ -134,7 +134,7 @@ func (suite *BaseOpenStackTestSuite) SetupTest() {
 
 	os.Setenv("OS_CLIENT_CONFIG_FILE", path.Join(baseFixturePath, "test_config.yaml"))
 
-	exporter, err := NewExporter(suite.ServiceName, suite.Prefix, cloudName, []string{}, "public", false, false, false, false, func() (string, error) {
+	exporter, err := NewExporter(suite.ServiceName, suite.Prefix, cloudName, []string{}, "public", false, false, false, false, "", func() (string, error) {
 		return DEFAULT_UUID, nil
 	})
 

--- a/exporters/keystone.go
+++ b/exporters/keystone.go
@@ -65,7 +65,7 @@ func ListDomains(exporter *BaseOpenStackExporter, ch chan<- prometheus.Metric) e
 func ListProjects(exporter *BaseOpenStackExporter, ch chan<- prometheus.Metric) error {
 	var allProjects []projects.Project
 
-	allPagesProject, err := projects.List(exporter.Client, projects.ListOpts{}).AllPages()
+	allPagesProject, err := projects.List(exporter.Client, projects.ListOpts{DomainID: exporter.DomainID}).AllPages()
 	if err != nil {
 		return err
 	}
@@ -108,7 +108,7 @@ func ListRegions(exporter *BaseOpenStackExporter, ch chan<- prometheus.Metric) e
 func ListUsers(exporter *BaseOpenStackExporter, ch chan<- prometheus.Metric) error {
 	var allUsers []users.User
 
-	allPagesUser, err := users.List(exporter.Client, users.ListOpts{}).AllPages()
+	allPagesUser, err := users.List(exporter.Client, users.ListOpts{DomainID: exporter.DomainID}).AllPages()
 	if err != nil {
 		return err
 	}
@@ -126,7 +126,7 @@ func ListUsers(exporter *BaseOpenStackExporter, ch chan<- prometheus.Metric) err
 func ListGroups(exporter *BaseOpenStackExporter, ch chan<- prometheus.Metric) error {
 	var allGroups []groups.Group
 
-	allPagesGroup, err := groups.List(exporter.Client, groups.ListOpts{}).AllPages()
+	allPagesGroup, err := groups.List(exporter.Client, groups.ListOpts{DomainID: exporter.DomainID}).AllPages()
 	if err != nil {
 		return err
 	}

--- a/exporters/nova.go
+++ b/exporters/nova.go
@@ -322,7 +322,7 @@ func ListComputeLimits(exporter *BaseOpenStackExporter, ch chan<- prometheus.Met
 		return err
 	}
 
-	allPagesProject, err := projects.List(c, projects.ListOpts{}).AllPages()
+	allPagesProject, err := projects.List(c, projects.ListOpts{DomainID: exporter.DomainID}).AllPages()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
For services supporting domain options, provide
the DomainID to filter metrics for.

New flag `--domain-id` added.
Default behavior is still to gather metrics for all
domains.

Closes #110

This could improve scrape time if openstack cloud has a lot
of heat stacks for example (~1min less for ~1500 heat stacks).

Currently, this only support Domain **ID** (not Name),  a future improvement
could be to support domain names, a list of domains, and/or a regex filter (but this will imply more API calls..)