### PR TITLE
openstack_nova_flavor_info metric has been added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@ vendor
 # Release tarballs
 *.tar.gz
 *coverage*
+
+# IDE dirs
+.idea/
+

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,5 @@ vendor
 *.tar.gz
 *coverage*
 
-# IDE dirs
+# JetBrains GoLand dir
 .idea/
-

--- a/README.md
+++ b/README.md
@@ -749,15 +749,15 @@ openstack_nova_current_workload{aggregate="",hostname="compute-node-extra-42",re
 openstack_nova_current_workload{aggregate="",hostname="compute-node-extra-43",region="Region"} 0.0
 openstack_nova_current_workload{aggregate="",hostname="compute-node-extra-44",region="Region"} 0.0
 openstack_nova_current_workload{aggregate="",hostname="compute-node-extra-45",region="Region"} 0.0
-# HELP openstack_nova_flavor_info flavor_info
-# TYPE openstack_nova_flavor_info gauge
-openstack_nova_flavor_info{disk="0",id="1",is_public="false",name="m1.tiny",ram="0",vcpus="0"} 1
-openstack_nova_flavor_info{disk="0",id="2",is_public="false",name="m1.small",ram="0",vcpus="0"} 1
-openstack_nova_flavor_info{disk="0",id="3",is_public="false",name="m1.medium",ram="0",vcpus="0"} 1
-openstack_nova_flavor_info{disk="0",id="4",is_public="false",name="m1.large",ram="0",vcpus="0"} 1
-openstack_nova_flavor_info{disk="0",id="5",is_public="false",name="m1.xlarge",ram="0",vcpus="0"} 1
-openstack_nova_flavor_info{disk="0",id="6",is_public="false",name="m1.tiny.specs",ram="0",vcpus="0"} 1
-openstack_nova_flavor_info{disk="0",id="7",is_public="false",name="m1.small.description",ram="0",vcpus="0"} 1
+# HELP openstack_nova_flavor flavor_info
+# TYPE openstack_nova_flavor gauge
+openstack_nova_flavor{disk="0",id="1",is_public="false",name="m1.tiny",ram="0",vcpus="0"} 1
+openstack_nova_flavor{disk="0",id="2",is_public="false",name="m1.small",ram="0",vcpus="0"} 1
+openstack_nova_flavor{disk="0",id="3",is_public="false",name="m1.medium",ram="0",vcpus="0"} 1
+openstack_nova_flavor{disk="0",id="4",is_public="false",name="m1.large",ram="0",vcpus="0"} 1
+openstack_nova_flavor{disk="0",id="5",is_public="false",name="m1.xlarge",ram="0",vcpus="0"} 1
+openstack_nova_flavor{disk="0",id="6",is_public="false",name="m1.tiny.specs",ram="0",vcpus="0"} 1
+openstack_nova_flavor{disk="0",id="7",is_public="false",name="m1.small.description",ram="0",vcpus="0"} 1
 # HELP openstack_nova_flavors flavors
 # TYPE openstack_nova_flavors gauge
 openstack_nova_flavors{region="Region"} 6.0

--- a/README.md
+++ b/README.md
@@ -276,6 +276,7 @@ openstack_loadbalancer_loadbalancer_status | id="607226db-27ef-4d41-ae89-f2a800e
 openstack_loadbalancer_total_amphorae| | 2 (float)
 openstack_loadbalancer_amphora_status|cert_expiration="2020-08-08T23:44:31Z",compute_id="667bb225-69aa-44b1-8908-694dc624c267",ha_ip="10.0.0.6",id="45f40289-0551-483a-b089-47214bc2a8a4",lb_network_ip="192.168.0.6",loadbalancer_id="882f2a9d-9d53-4bd0-b0e9-08e9d0de11f9",role="MASTER",status="READY"| 2.0 (float)
 openstack_nova_availability_zones|region="RegionOne"|4.0 (float)
+openstack_nova_flavor_info|region="RegionOne", "disk", "id", "is_public", "name", "ram", "vcpus"|1.0 (float)
 openstack_nova_flavors|region="RegionOne"|4.0 (float)
 openstack_nova_total_vms|region="RegionOne"|12.0 (float)
 openstack_nova_server_status|region="RegionOne",hostname="compute-01""id", "name", "tenant_id", "user_id", "address_ipv4",                                                                     	"address_ipv6", "host_id", "uuid", "availability_zone"|0.0 (float)
@@ -748,6 +749,15 @@ openstack_nova_current_workload{aggregate="",hostname="compute-node-extra-42",re
 openstack_nova_current_workload{aggregate="",hostname="compute-node-extra-43",region="Region"} 0.0
 openstack_nova_current_workload{aggregate="",hostname="compute-node-extra-44",region="Region"} 0.0
 openstack_nova_current_workload{aggregate="",hostname="compute-node-extra-45",region="Region"} 0.0
+# HELP openstack_nova_flavor_info flavor_info
+# TYPE openstack_nova_flavor_info gauge
+openstack_nova_flavor_info{disk="0",id="1",is_public="false",name="m1.tiny",ram="0",vcpus="0"} 1
+openstack_nova_flavor_info{disk="0",id="2",is_public="false",name="m1.small",ram="0",vcpus="0"} 1
+openstack_nova_flavor_info{disk="0",id="3",is_public="false",name="m1.medium",ram="0",vcpus="0"} 1
+openstack_nova_flavor_info{disk="0",id="4",is_public="false",name="m1.large",ram="0",vcpus="0"} 1
+openstack_nova_flavor_info{disk="0",id="5",is_public="false",name="m1.xlarge",ram="0",vcpus="0"} 1
+openstack_nova_flavor_info{disk="0",id="6",is_public="false",name="m1.tiny.specs",ram="0",vcpus="0"} 1
+openstack_nova_flavor_info{disk="0",id="7",is_public="false",name="m1.small.description",ram="0",vcpus="0"} 1
 # HELP openstack_nova_flavors flavors
 # TYPE openstack_nova_flavors gauge
 openstack_nova_flavors{region="Region"} 6.0

--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ openstack_loadbalancer_loadbalancer_status | id="607226db-27ef-4d41-ae89-f2a800e
 openstack_loadbalancer_total_amphorae| | 2 (float)
 openstack_loadbalancer_amphora_status|cert_expiration="2020-08-08T23:44:31Z",compute_id="667bb225-69aa-44b1-8908-694dc624c267",ha_ip="10.0.0.6",id="45f40289-0551-483a-b089-47214bc2a8a4",lb_network_ip="192.168.0.6",loadbalancer_id="882f2a9d-9d53-4bd0-b0e9-08e9d0de11f9",role="MASTER",status="READY"| 2.0 (float)
 openstack_nova_availability_zones|region="RegionOne"|4.0 (float)
-openstack_nova_flavor_info|region="RegionOne", "disk", "id", "is_public", "name", "ram", "vcpus"|1.0 (float)
+openstack_nova_flavor|"disk", "id", "is_public", "name", "ram", "vcpus"|1.0 (float)
 openstack_nova_flavors|region="RegionOne"|4.0 (float)
 openstack_nova_total_vms|region="RegionOne"|12.0 (float)
 openstack_nova_server_status|region="RegionOne",hostname="compute-01""id", "name", "tenant_id", "user_id", "address_ipv4",                                                                     	"address_ipv6", "host_id", "uuid", "availability_zone"|0.0 (float)
@@ -749,7 +749,7 @@ openstack_nova_current_workload{aggregate="",hostname="compute-node-extra-42",re
 openstack_nova_current_workload{aggregate="",hostname="compute-node-extra-43",region="Region"} 0.0
 openstack_nova_current_workload{aggregate="",hostname="compute-node-extra-44",region="Region"} 0.0
 openstack_nova_current_workload{aggregate="",hostname="compute-node-extra-45",region="Region"} 0.0
-# HELP openstack_nova_flavor flavor_info
+# HELP openstack_nova_flavor flavor
 # TYPE openstack_nova_flavor gauge
 openstack_nova_flavor{disk="0",id="1",is_public="false",name="m1.tiny",ram="0",vcpus="0"} 1
 openstack_nova_flavor{disk="0",id="2",is_public="false",name="m1.small",ram="0",vcpus="0"} 1

--- a/exporters/nova.go
+++ b/exporters/nova.go
@@ -61,7 +61,8 @@ type NovaExporter struct {
 }
 
 var defaultNovaMetrics = []Metric{
-	{Name: "flavors", Fn: ListFlavors},
+	{Name: "flavors"},
+	{Name: "flavor_info", Labels: []string{"id", "name", "vcpus", "ram", "disk", "is_public"}, Fn: ListFlavors},
 	{Name: "availability_zones", Fn: ListAZs},
 	{Name: "security_groups", Fn: ListComputeSecGroups},
 	{Name: "total_vms", Fn: ListAllServers},
@@ -230,6 +231,10 @@ func ListFlavors(exporter *BaseOpenStackExporter, ch chan<- prometheus.Metric) e
 
 	ch <- prometheus.MustNewConstMetric(exporter.Metrics["flavors"].Metric,
 		prometheus.GaugeValue, float64(len(allFlavors)))
+	for _, f := range allFlavors {
+		ch <- prometheus.MustNewConstMetric(exporter.Metrics["flavor_info"].Metric,
+			prometheus.GaugeValue, 1.0, f.ID, f.Name, fmt.Sprintf("%v", f.VCPUs), fmt.Sprintf("%v", f.RAM), fmt.Sprintf("%v", f.Disk), fmt.Sprintf("%v", f.IsPublic))
+	}
 
 	return nil
 }

--- a/exporters/nova.go
+++ b/exporters/nova.go
@@ -61,8 +61,8 @@ type NovaExporter struct {
 }
 
 var defaultNovaMetrics = []Metric{
-	{Name: "flavors"},
-	{Name: "flavor_info", Labels: []string{"id", "name", "vcpus", "ram", "disk", "is_public"}, Fn: ListFlavors},
+	{Name: "flavors", Fn: ListFlavors},
+	{Name: "flavor", Labels: []string{"id", "name", "vcpus", "ram", "disk", "is_public"}},
 	{Name: "availability_zones", Fn: ListAZs},
 	{Name: "security_groups", Fn: ListComputeSecGroups},
 	{Name: "total_vms", Fn: ListAllServers},
@@ -232,8 +232,8 @@ func ListFlavors(exporter *BaseOpenStackExporter, ch chan<- prometheus.Metric) e
 	ch <- prometheus.MustNewConstMetric(exporter.Metrics["flavors"].Metric,
 		prometheus.GaugeValue, float64(len(allFlavors)))
 	for _, f := range allFlavors {
-		ch <- prometheus.MustNewConstMetric(exporter.Metrics["flavor_info"].Metric,
-			prometheus.GaugeValue, 1.0, f.ID, f.Name, fmt.Sprintf("%v", f.VCPUs), fmt.Sprintf("%v", f.RAM), fmt.Sprintf("%v", f.Disk), fmt.Sprintf("%v", f.IsPublic))
+		ch <- prometheus.MustNewConstMetric(exporter.Metrics["flavor"].Metric,
+			prometheus.GaugeValue, 1, f.ID, f.Name, fmt.Sprintf("%v", f.VCPUs), fmt.Sprintf("%v", f.RAM), fmt.Sprintf("%v", f.Disk), fmt.Sprintf("%v", f.IsPublic))
 	}
 
 	return nil

--- a/exporters/nova_test.go
+++ b/exporters/nova_test.go
@@ -24,6 +24,15 @@ openstack_nova_availability_zones 1
 # HELP openstack_nova_current_workload current_workload
 # TYPE openstack_nova_current_workload gauge
 openstack_nova_current_workload{aggregates="",availability_zone="",hostname="host1"} 0
+# HELP openstack_nova_flavor_info flavor_info
+# TYPE openstack_nova_flavor_info gauge
+openstack_nova_flavor_info{disk="0",id="1",is_public="false",name="m1.tiny",ram="0",vcpus="0"} 1
+openstack_nova_flavor_info{disk="0",id="2",is_public="false",name="m1.small",ram="0",vcpus="0"} 1
+openstack_nova_flavor_info{disk="0",id="3",is_public="false",name="m1.medium",ram="0",vcpus="0"} 1
+openstack_nova_flavor_info{disk="0",id="4",is_public="false",name="m1.large",ram="0",vcpus="0"} 1
+openstack_nova_flavor_info{disk="0",id="5",is_public="false",name="m1.xlarge",ram="0",vcpus="0"} 1
+openstack_nova_flavor_info{disk="0",id="6",is_public="false",name="m1.tiny.specs",ram="0",vcpus="0"} 1
+openstack_nova_flavor_info{disk="0",id="7",is_public="false",name="m1.small.description",ram="0",vcpus="0"} 1
 # HELP openstack_nova_flavors flavors
 # TYPE openstack_nova_flavors gauge
 openstack_nova_flavors 7

--- a/exporters/nova_test.go
+++ b/exporters/nova_test.go
@@ -24,15 +24,15 @@ openstack_nova_availability_zones 1
 # HELP openstack_nova_current_workload current_workload
 # TYPE openstack_nova_current_workload gauge
 openstack_nova_current_workload{aggregates="",availability_zone="",hostname="host1"} 0
-# HELP openstack_nova_flavor_info flavor_info
-# TYPE openstack_nova_flavor_info gauge
-openstack_nova_flavor_info{disk="0",id="1",is_public="false",name="m1.tiny",ram="0",vcpus="0"} 1
-openstack_nova_flavor_info{disk="0",id="2",is_public="false",name="m1.small",ram="0",vcpus="0"} 1
-openstack_nova_flavor_info{disk="0",id="3",is_public="false",name="m1.medium",ram="0",vcpus="0"} 1
-openstack_nova_flavor_info{disk="0",id="4",is_public="false",name="m1.large",ram="0",vcpus="0"} 1
-openstack_nova_flavor_info{disk="0",id="5",is_public="false",name="m1.xlarge",ram="0",vcpus="0"} 1
-openstack_nova_flavor_info{disk="0",id="6",is_public="false",name="m1.tiny.specs",ram="0",vcpus="0"} 1
-openstack_nova_flavor_info{disk="0",id="7",is_public="false",name="m1.small.description",ram="0",vcpus="0"} 1
+# HELP openstack_nova_flavor flavor
+# TYPE openstack_nova_flavor gauge
+openstack_nova_flavor{disk="0",id="1",is_public="false",name="m1.tiny",ram="0",vcpus="0"} 1
+openstack_nova_flavor{disk="0",id="2",is_public="false",name="m1.small",ram="0",vcpus="0"} 1
+openstack_nova_flavor{disk="0",id="3",is_public="false",name="m1.medium",ram="0",vcpus="0"} 1
+openstack_nova_flavor{disk="0",id="4",is_public="false",name="m1.large",ram="0",vcpus="0"} 1
+openstack_nova_flavor{disk="0",id="5",is_public="false",name="m1.xlarge",ram="0",vcpus="0"} 1
+openstack_nova_flavor{disk="0",id="6",is_public="false",name="m1.tiny.specs",ram="0",vcpus="0"} 1
+openstack_nova_flavor{disk="0",id="7",is_public="false",name="m1.small.description",ram="0",vcpus="0"} 1
 # HELP openstack_nova_flavors flavors
 # TYPE openstack_nova_flavors gauge
 openstack_nova_flavors 7


### PR DESCRIPTION
openstack_nova_flavor_info metric was added to exporter.

### Metrics example from my stage
`openstack_nova_flavor{disk="0",id="5f2122e5-9001-40ad-8b4c-55434fa10b9b",is_public="true",name="t1.nano",ram="256",vcpus="1"} 1`

`openstack_nova_flavor{disk="0",id="9712c77e-325b-4469-8801-4a83eb98ebb6",is_public="true",name="t1.kilo",ram="1024",vcpus="1"} 1`