### PR TITLE
Fix flavor metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -789,16 +789,17 @@ openstack_nova_current_workload{aggregate="",hostname="compute-node-extra-44",re
 openstack_nova_current_workload{aggregate="",hostname="compute-node-extra-45",region="Region"} 0.0
 # HELP openstack_nova_flavor flavor
 # TYPE openstack_nova_flavor gauge
-openstack_nova_flavor{disk="0",id="1",is_public="false",name="m1.tiny",ram="0",vcpus="0"} 1
-openstack_nova_flavor{disk="0",id="2",is_public="false",name="m1.small",ram="0",vcpus="0"} 1
-openstack_nova_flavor{disk="0",id="3",is_public="false",name="m1.medium",ram="0",vcpus="0"} 1
-openstack_nova_flavor{disk="0",id="4",is_public="false",name="m1.large",ram="0",vcpus="0"} 1
-openstack_nova_flavor{disk="0",id="5",is_public="false",name="m1.xlarge",ram="0",vcpus="0"} 1
-openstack_nova_flavor{disk="0",id="6",is_public="false",name="m1.tiny.specs",ram="0",vcpus="0"} 1
-openstack_nova_flavor{disk="0",id="7",is_public="false",name="m1.small.description",ram="0",vcpus="0"} 1
+openstack_nova_flavor{disk="0",id="1",is_public="true",name="m1.tiny",ram="512",vcpus="1"} 1
+openstack_nova_flavor{disk="0",id="2",is_public="true",name="m1.small",ram="2048",vcpus="1"} 1
+openstack_nova_flavor{disk="0",id="3",is_public="true",name="m1.medium",ram="4096",vcpus="2"} 1
+openstack_nova_flavor{disk="0",id="4",is_public="true",name="m1.large",ram="8192",vcpus="4"} 1
+openstack_nova_flavor{disk="0",id="5",is_public="true",name="m1.xlarge",ram="16384",vcpus="8"} 1
+openstack_nova_flavor{disk="0",id="6",is_public="true",name="m1.tiny.specs",ram="512",vcpus="1"} 1
+openstack_nova_flavor{disk="0",id="7",is_public="true",name="m1.small.description",ram="2048",vcpus="1"} 1
+openstack_nova_flavor{disk="0",id="8",is_public="false",name="m1.tiny.private",ram="512",vcpus="1"} 1
 # HELP openstack_nova_flavors flavors
 # TYPE openstack_nova_flavors gauge
-openstack_nova_flavors{region="Region"} 6.0
+openstack_nova_flavors{region="Region"} 8
 # TYPE openstack_nova_free_disk_bytes gauge
 openstack_nova_free_disk_bytes{aggregates="",availability_zone="",hostname="host1"} 1.103806595072e+12
 # HELP openstack_nova_local_storage_available_bytes local_storage_available_bytes

--- a/exporters/fixtures/nova_os_flavors.json
+++ b/exporters/fixtures/nova_os_flavors.json
@@ -1,6 +1,10 @@
 {
   "flavors": [
     {
+      "OS-FLV-DISABLED:disabled": false,
+      "disk": 0,
+      "OS-FLV-EXT-DATA:ephemeral": 0,
+      "os-flavor-access:is_public": true,
       "id": "1",
       "links": [
         {
@@ -13,9 +17,18 @@
         }
       ],
       "name": "m1.tiny",
-      "description": null
+      "ram": 512,
+      "swap": 0,
+      "vcpus": 1,
+      "rxtx_factor": 1,
+      "description": null,
+      "extra_specs": {}
     },
     {
+      "OS-FLV-DISABLED:disabled": false,
+      "disk": 0,
+      "OS-FLV-EXT-DATA:ephemeral": 0,
+      "os-flavor-access:is_public": true,
       "id": "2",
       "links": [
         {
@@ -28,9 +41,18 @@
         }
       ],
       "name": "m1.small",
-      "description": null
+      "ram": 2048,
+      "swap": 0,
+      "vcpus": 1,
+      "rxtx_factor": 1,
+      "description": null,
+      "extra_specs": {}
     },
     {
+      "OS-FLV-DISABLED:disabled": false,
+      "disk": 0,
+      "OS-FLV-EXT-DATA:ephemeral": 0,
+      "os-flavor-access:is_public": true,
       "id": "3",
       "links": [
         {
@@ -43,9 +65,18 @@
         }
       ],
       "name": "m1.medium",
-      "description": null
+      "ram": 4096,
+      "swap": 0,
+      "vcpus": 2,
+      "rxtx_factor": 1,
+      "description": null,
+      "extra_specs": {}
     },
     {
+      "OS-FLV-DISABLED:disabled": false,
+      "disk": 0,
+      "OS-FLV-EXT-DATA:ephemeral": 0,
+      "os-flavor-access:is_public": true,
       "id": "4",
       "links": [
         {
@@ -58,9 +89,18 @@
         }
       ],
       "name": "m1.large",
-      "description": null
+      "ram": 8192,
+      "swap": 0,
+      "vcpus": 4,
+      "rxtx_factor": 1,
+      "description": null,
+      "extra_specs": {}
     },
     {
+      "OS-FLV-DISABLED:disabled": false,
+      "disk": 0,
+      "OS-FLV-EXT-DATA:ephemeral": 0,
+      "os-flavor-access:is_public": true,
       "id": "5",
       "links": [
         {
@@ -73,9 +113,18 @@
         }
       ],
       "name": "m1.xlarge",
-      "description": null
+      "ram": 16384,
+      "swap": 0,
+      "vcpus": 8,
+      "rxtx_factor": 1,
+      "description": null,
+      "extra_specs": {}
     },
     {
+      "OS-FLV-DISABLED:disabled": false,
+      "disk": 0,
+      "OS-FLV-EXT-DATA:ephemeral": 0,
+      "os-flavor-access:is_public": true,
       "id": "6",
       "links": [
         {
@@ -88,9 +137,20 @@
         }
       ],
       "name": "m1.tiny.specs",
-      "description": null
+      "ram": 512,
+      "swap": 0,
+      "vcpus": 1,
+      "rxtx_factor": 1,
+      "description": null,
+      "extra_specs": {
+        "hw:numa_nodes": "1"
+      }
     },
     {
+      "OS-FLV-DISABLED:disabled": false,
+      "disk": 0,
+      "OS-FLV-EXT-DATA:ephemeral": 0,
+      "os-flavor-access:is_public": true,
       "id": "7",
       "links": [
         {
@@ -103,7 +163,39 @@
         }
       ],
       "name": "m1.small.description",
-      "description": "test description"
+      "ram": 2048,
+      "swap": 0,
+      "vcpus": 1,
+      "rxtx_factor": 1,
+      "description": "test description",
+      "extra_specs": {
+        "hw:cpu_policy": "shared",
+        "hw:numa_nodes": "1"
+      }
+    },
+    {
+      "OS-FLV-DISABLED:disabled": false,
+      "disk": 0,
+      "OS-FLV-EXT-DATA:ephemeral": 0,
+      "os-flavor-access:is_public": false,
+      "id": "8",
+      "links": [
+        {
+          "href": "http://openstack.example.com/v2/6f70656e737461636b20342065766572/flavors/8",
+          "rel": "self"
+        },
+        {
+          "href": "http://openstack.example.com/6f70656e737461636b20342065766572/flavors/8",
+          "rel": "bookmark"
+        }
+      ],
+      "name": "m1.tiny.private",
+      "ram": 512,
+      "swap": 0,
+      "vcpus": 1,
+      "rxtx_factor": 1,
+      "description": null,
+      "extra_specs": {}
     }
   ]
 }

--- a/exporters/nova.go
+++ b/exporters/nova.go
@@ -221,7 +221,7 @@ func ListHypervisors(exporter *BaseOpenStackExporter, ch chan<- prometheus.Metri
 func ListFlavors(exporter *BaseOpenStackExporter, ch chan<- prometheus.Metric) error {
 	var allFlavors []flavors.Flavor
 
-	allPagesFlavors, err := flavors.ListDetail(exporter.Client, flavors.ListOpts{}).AllPages()
+	allPagesFlavors, err := flavors.ListDetail(exporter.Client, flavors.ListOpts{AccessType: "None"}).AllPages()
 	if err != nil {
 		return err
 	}

--- a/exporters/nova_test.go
+++ b/exporters/nova_test.go
@@ -26,16 +26,17 @@ openstack_nova_availability_zones 1
 openstack_nova_current_workload{aggregates="",availability_zone="",hostname="host1"} 0
 # HELP openstack_nova_flavor flavor
 # TYPE openstack_nova_flavor gauge
-openstack_nova_flavor{disk="0",id="1",is_public="false",name="m1.tiny",ram="0",vcpus="0"} 1
-openstack_nova_flavor{disk="0",id="2",is_public="false",name="m1.small",ram="0",vcpus="0"} 1
-openstack_nova_flavor{disk="0",id="3",is_public="false",name="m1.medium",ram="0",vcpus="0"} 1
-openstack_nova_flavor{disk="0",id="4",is_public="false",name="m1.large",ram="0",vcpus="0"} 1
-openstack_nova_flavor{disk="0",id="5",is_public="false",name="m1.xlarge",ram="0",vcpus="0"} 1
-openstack_nova_flavor{disk="0",id="6",is_public="false",name="m1.tiny.specs",ram="0",vcpus="0"} 1
-openstack_nova_flavor{disk="0",id="7",is_public="false",name="m1.small.description",ram="0",vcpus="0"} 1
+openstack_nova_flavor{disk="0",id="1",is_public="true",name="m1.tiny",ram="512",vcpus="1"} 1
+openstack_nova_flavor{disk="0",id="2",is_public="true",name="m1.small",ram="2048",vcpus="1"} 1
+openstack_nova_flavor{disk="0",id="3",is_public="true",name="m1.medium",ram="4096",vcpus="2"} 1
+openstack_nova_flavor{disk="0",id="4",is_public="true",name="m1.large",ram="8192",vcpus="4"} 1
+openstack_nova_flavor{disk="0",id="5",is_public="true",name="m1.xlarge",ram="16384",vcpus="8"} 1
+openstack_nova_flavor{disk="0",id="6",is_public="true",name="m1.tiny.specs",ram="512",vcpus="1"} 1
+openstack_nova_flavor{disk="0",id="7",is_public="true",name="m1.small.description",ram="2048",vcpus="1"} 1
+openstack_nova_flavor{disk="0",id="8",is_public="false",name="m1.tiny.private",ram="512",vcpus="1"} 1
 # HELP openstack_nova_flavors flavors
 # TYPE openstack_nova_flavors gauge
-openstack_nova_flavors 7
+openstack_nova_flavors 8
 # HELP openstack_nova_free_disk_bytes free_disk_bytes
 # TYPE openstack_nova_free_disk_bytes gauge
 openstack_nova_free_disk_bytes{aggregates="",availability_zone="",hostname="host1"} 1.103806595072e+12


### PR DESCRIPTION
#### nova_flavor metrics fix
* nova_flavor metrics were collecting incorrectly because the `AccessType` parameter wasn't added.
openstack_exporter was only collecting flavors from the current project.
* Also, the fixtures/nova_os_flavors.json has been changed to correct one.