### PR TITLE
Fix <nil> values in nova_server_status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1058,6 +1058,9 @@ openstack_nova_security_groups{region="Region"} 5.0
 # HELP openstack_nova_server_local_gb server_local_gb
 # TYPE openstack_nova_server_local_gb gauge
 openstack_nova_server_local_gb{id="27bb2854-b06a-48f5-ab4e-139817b8b8ff",name="openstack-monitoring-0",tenant_id="110f6313d2d346b4aa90eabe4970b62a"} 10
+# HELP openstack_nova_server_status server_status
+# TYPE openstack_nova_server_status gauge
+openstack_nova_server_status{address_ipv4="1.2.3.4",address_ipv6="80fe::",availability_zone="nova",flavor_id="1",host_id="2091634baaccdc4c5a1d57069c833e402921df696b7f970791b12ec6",hypervisor_hostname="fake-mini",id="2ce4c5b3-2866-4972-93ce-77a2ea46a7f9",name="new-server-test",status="ACTIVE",tenant_id="6f70656e737461636b20342065766572",user_id="fake",uuid="2ce4c5b3-2866-4972-93ce-77a2ea46a7f9"} 0
 # HELP openstack_nova_total_vms total_vms
 # TYPE openstack_nova_total_vms gauge
 openstack_nova_total_vms{region="Region"} 23.0

--- a/exporters/fixtures/nova_api_v2.1.json
+++ b/exporters/fixtures/nova_api_v2.1.json
@@ -1,27 +1,26 @@
 {
-  "versions": 
-    {
-       "id": "v2.1",
-       "status": "CURRENT",
-       "version": "2.87",
-       "min_version": "2.1",
-       "updated": "2013-07-23T11:33:21Z",
-       "links": [
-         {
-            "rel": "self",
-            "href": "http://test.cloud:8774/v2.1/"
-         },
-         {
-            "rel": "describedby",
-            "type": "text/html",
-            "href": "http://docs.openstack.org/"
-        }
-        ],
-        "media-types": [
-          {
-             "base": "application/json",
-             "type": "application/vnd.openstack.compute+json;version=2.1"
-         }
-        ]
-    }
+  "version": {
+    "id": "v2.1",
+    "links": [
+      {
+        "href": "http://openstack.example.com/v2.1/",
+        "rel": "self"
+      },
+      {
+        "href": "http://docs.openstack.org/",
+        "rel": "describedby",
+        "type": "text/html"
+      }
+    ],
+    "media-types": [
+      {
+        "base": "application/json",
+        "type": "application/vnd.openstack.compute+json;version=2.1"
+      }
+    ],
+    "status": "CURRENT",
+    "version": "2.95",
+    "min_version": "2.1",
+    "updated": "2013-07-23T11:33:21Z"
+  }
 }

--- a/exporters/fixtures/nova_os_servers.json
+++ b/exporters/fixtures/nova_os_servers.json
@@ -34,7 +34,7 @@
       "created": "2019-04-23T15:19:14Z",
       "description": null,
       "flavor": {
-        "disk": 1,
+        "disk": 0,
         "ephemeral": 0,
         "extra_specs": {},
         "original_name": "m1.tiny",

--- a/exporters/nova.go
+++ b/exporters/nova.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"sort"
+	"strconv"
 
 	"github.com/go-kit/log"
 	"github.com/gophercloud/gophercloud"
@@ -55,6 +56,16 @@ func mapServerStatus(current string) int {
 		}
 	}
 	return -1
+}
+
+func searchFlavorIDbyName(flavorName interface{}, allFlavors []flavors.Flavor) string {
+	// flavor name is unique, making it suitable as the key for searching
+	for _, f := range allFlavors {
+		if f.Name == flavorName {
+			return f.ID
+		}
+	}
+	return ""
 }
 
 type NovaExporter struct {
@@ -285,6 +296,7 @@ func ListAllServers(exporter *BaseOpenStackExporter, ch chan<- prometheus.Metric
 	}
 
 	var allServers []ServerWithExt
+	var allFlavors []flavors.Flavor
 
 	allPagesServers, err := servers.List(exporter.Client, servers.ListOpts{AllTenants: true}).AllPages()
 	if err != nil {
@@ -298,12 +310,35 @@ func ListAllServers(exporter *BaseOpenStackExporter, ch chan<- prometheus.Metric
 
 	ch <- prometheus.MustNewConstMetric(exporter.Metrics["total_vms"].Metric,
 		prometheus.GaugeValue, float64(len(allServers)))
-
+	apiMv, _ := strconv.ParseFloat(exporter.Client.Microversion, 64)
+	if apiMv >= 2.46 {
+		// https://docs.openstack.org/api-ref/compute/#list-servers-detailed
+		// ***
+		// If micro-version is greater than 2.46,
+		// we need to retrieve all flavors once again and search for flavor_id by name,
+		// as flavor_id are only available in server's detail data up to that version.
+		allPagesFlavors, err := flavors.ListDetail(exporter.Client, flavors.ListOpts{AccessType: "None"}).AllPages()
+		if err != nil {
+			return err
+		}
+		allFlavors, err = flavors.ExtractFlavors(allPagesFlavors)
+		if err != nil {
+			return err
+		}
+	}
 	// Server status metrics
 	for _, server := range allServers {
-		ch <- prometheus.MustNewConstMetric(exporter.Metrics["server_status"].Metric,
-			prometheus.GaugeValue, float64(mapServerStatus(server.Status)), server.ID, server.Status, server.Name, server.TenantID,
-			server.UserID, server.AccessIPv4, server.AccessIPv6, server.HostID, server.HypervisorHostname, server.ID, server.AvailabilityZone, fmt.Sprintf("%v", server.Flavor["id"]))
+		if len(allFlavors) == 0 {
+			ch <- prometheus.MustNewConstMetric(exporter.Metrics["server_status"].Metric,
+				prometheus.GaugeValue, float64(mapServerStatus(server.Status)), server.ID, server.Status, server.Name, server.TenantID,
+				server.UserID, server.AccessIPv4, server.AccessIPv6, server.HostID, server.HypervisorHostname, server.ID,
+				server.AvailabilityZone, fmt.Sprintf("%v", server.Flavor["id"]))
+		} else {
+			ch <- prometheus.MustNewConstMetric(exporter.Metrics["server_status"].Metric,
+				prometheus.GaugeValue, float64(mapServerStatus(server.Status)), server.ID, server.Status, server.Name, server.TenantID,
+				server.UserID, server.AccessIPv4, server.AccessIPv6, server.HostID, server.HypervisorHostname, server.ID,
+				server.AvailabilityZone, searchFlavorIDbyName(server.Flavor["original_name"], allFlavors))
+		}
 	}
 
 	return nil

--- a/exporters/nova_test.go
+++ b/exporters/nova_test.go
@@ -126,7 +126,7 @@ openstack_nova_server_local_gb{id="6c773231-6532-447d-b651-9e0d1518b31d",name="o
 openstack_nova_server_local_gb{id="f99bb4a3-90ff-46fa-b8ec-2ef6ac1f3b7d",name="openstack-monitoring-2-prod-zone",tenant_id="110f6313d2d346b4aa90eabe4970b62a"} 10
 # HELP openstack_nova_server_status server_status
 # TYPE openstack_nova_server_status gauge
-openstack_nova_server_status{address_ipv4="1.2.3.4",address_ipv6="80fe::",availability_zone="nova",flavor_id="<nil>",host_id="2091634baaccdc4c5a1d57069c833e402921df696b7f970791b12ec6",hypervisor_hostname="fake-mini",id="2ce4c5b3-2866-4972-93ce-77a2ea46a7f9",name="new-server-test",status="ACTIVE",tenant_id="6f70656e737461636b20342065766572",user_id="fake",uuid="2ce4c5b3-2866-4972-93ce-77a2ea46a7f9"} 0
+openstack_nova_server_status{address_ipv4="1.2.3.4",address_ipv6="80fe::",availability_zone="nova",flavor_id="1",host_id="2091634baaccdc4c5a1d57069c833e402921df696b7f970791b12ec6",hypervisor_hostname="fake-mini",id="2ce4c5b3-2866-4972-93ce-77a2ea46a7f9",name="new-server-test",status="ACTIVE",tenant_id="6f70656e737461636b20342065766572",user_id="fake",uuid="2ce4c5b3-2866-4972-93ce-77a2ea46a7f9"} 0
 # HELP openstack_nova_total_vms total_vms
 # TYPE openstack_nova_total_vms gauge
 openstack_nova_total_vms 1


### PR DESCRIPTION
#220 server_status flavor_id label is always returning `nil` value:
    Starting from micro-version 2.47, `flavor.id` is no longer available in detailed server data.
    The data now only contains `flavor.name`.
    This fix involves retrieving all flavors and subsequently searching for flavor.id based on its name.