### PR TITLE
Fix flavor_id="<nil>" when OS_COMPUTE_API_VERSION=latest

### DIFF
--- a/exporters/nova.go
+++ b/exporters/nova.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"sort"
 	"strconv"
+	"strings"
 
 	"github.com/go-kit/log"
 	"github.com/gophercloud/gophercloud"
@@ -117,7 +118,7 @@ func NewNovaExporter(config *ExporterConfig, logger log.Logger) (*NovaExporter, 
 	}
 
 	envMicroversion, present := os.LookupEnv("OS_COMPUTE_API_VERSION")
-	if present {
+	if present && !strings.EqualFold(envMicroversion, "latest") {
 		exporter.Client.Microversion = envMicroversion
 	} else {
 


### PR DESCRIPTION
Fix 'flavor_id="<nil>"' when "OS_COMPUTE_API_VERSION=latest" by getting actual API version like if no OS_COMPUTE_API_VERSION was set
