### PR TITLE
Fix crash on some metrics disabling

### DIFF
--- a/exporters/keystone.go
+++ b/exporters/keystone.go
@@ -79,13 +79,14 @@ func ListProjects(exporter *BaseOpenStackExporter, ch chan<- prometheus.Metric) 
 
 	ch <- prometheus.MustNewConstMetric(exporter.Metrics["projects"].Metric,
 		prometheus.GaugeValue, float64(len(allProjects)))
-	for _, p := range allProjects {
-		ch <- prometheus.MustNewConstMetric(exporter.Metrics["project_info"].Metric,
-			prometheus.GaugeValue, 1.0, strconv.FormatBool(p.IsDomain),
-			p.Description, p.DomainID, strconv.FormatBool(p.Enabled), p.ID, p.Name,
-			p.ParentID)
+	if !exporter.MetricIsDisabled("project_info") {
+		for _, p := range allProjects {
+			ch <- prometheus.MustNewConstMetric(exporter.Metrics["project_info"].Metric,
+				prometheus.GaugeValue, 1.0, strconv.FormatBool(p.IsDomain),
+				p.Description, p.DomainID, strconv.FormatBool(p.Enabled), p.ID, p.Name,
+				p.ParentID)
+		}
 	}
-
 	return nil
 }
 

--- a/exporters/nova.go
+++ b/exporters/nova.go
@@ -327,20 +327,21 @@ func ListAllServers(exporter *BaseOpenStackExporter, ch chan<- prometheus.Metric
 		}
 	}
 	// Server status metrics
-	for _, server := range allServers {
-		if len(allFlavors) == 0 {
-			ch <- prometheus.MustNewConstMetric(exporter.Metrics["server_status"].Metric,
-				prometheus.GaugeValue, float64(mapServerStatus(server.Status)), server.ID, server.Status, server.Name, server.TenantID,
-				server.UserID, server.AccessIPv4, server.AccessIPv6, server.HostID, server.HypervisorHostname, server.ID,
-				server.AvailabilityZone, fmt.Sprintf("%v", server.Flavor["id"]), server.InstanceName)
-		} else {
-			ch <- prometheus.MustNewConstMetric(exporter.Metrics["server_status"].Metric,
-				prometheus.GaugeValue, float64(mapServerStatus(server.Status)), server.ID, server.Status, server.Name, server.TenantID,
-				server.UserID, server.AccessIPv4, server.AccessIPv6, server.HostID, server.HypervisorHostname, server.ID,
-				server.AvailabilityZone, searchFlavorIDbyName(server.Flavor["original_name"], allFlavors), server.InstanceName)
+	if !exporter.MetricIsDisabled("server_status") {
+		for _, server := range allServers {
+			if len(allFlavors) == 0 {
+				ch <- prometheus.MustNewConstMetric(exporter.Metrics["server_status"].Metric,
+					prometheus.GaugeValue, float64(mapServerStatus(server.Status)), server.ID, server.Status, server.Name, server.TenantID,
+					server.UserID, server.AccessIPv4, server.AccessIPv6, server.HostID, server.HypervisorHostname, server.ID,
+					server.AvailabilityZone, fmt.Sprintf("%v", server.Flavor["id"]), server.InstanceName)
+			} else {
+				ch <- prometheus.MustNewConstMetric(exporter.Metrics["server_status"].Metric,
+					prometheus.GaugeValue, float64(mapServerStatus(server.Status)), server.ID, server.Status, server.Name, server.TenantID,
+					server.UserID, server.AccessIPv4, server.AccessIPv6, server.HostID, server.HypervisorHostname, server.ID,
+					server.AvailabilityZone, searchFlavorIDbyName(server.Flavor["original_name"], allFlavors), server.InstanceName)
+			}
 		}
 	}
-
 	return nil
 }
 


### PR DESCRIPTION
Currently, trying to disable the next high-cardinality metrics using command-line argument --disable-metric

keystone-identity_project_info
neutron-subnet
neutron-router
neutron-port
neutron-network
neutron-l3_agent_of_router
nova-server_status

causes exporter crash with an error like this:

`	/go/pkg/mod/github.com/prometheus/client_golang@v1.16.0/prometheus/registry.go:547 +0xbab
created by github.com/prometheus/client_golang/prometheus.(*Registry).Gather
	/go/pkg/mod/github.com/prometheus/client_golang@v1.16.0/prometheus/registry.go:455 +0xfb
github.com/prometheus/client_golang/prometheus.(*Registry).Gather.func1()
	/exporters/exporter.go:125 +0x110
github.com/openstack-exporter/openstack-exporter/exporters.(*BaseOpenStackExporter).Collect(0xc0001c6d80, 0xc0000a6f60?)
	/exporters/exporter.go:102 +0x2ba
github.com/openstack-exporter/openstack-exporter/exporters.(*BaseOpenStackExporter).RunCollection(0xc0001c6d80, 0xc00060fd80, {0xa511d9, 0x7}, 0x2?, {0xb2db00, 0xc0000d5040})
	/exporters/neutron.go:377 +0x78e
github.com/openstack-exporter/openstack-exporter/exporters.ListRouters(0xc0001c6d80, 0xc000634120?)
goroutine 139 [running]:
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x8bfeae]
panic: runtime error: invalid memory address or nil pointer dereference`

This commit resolves the problem.