### PR TITLE
Use CGO_ENABLED=0 for binary in container image to avoid GLIBC errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /
 
 COPY . .
 
-RUN go mod download && go build -o /openstack-exporter .
+RUN go mod download && CGO_ENABLED=0 go build -o /openstack-exporter .
 
 FROM gcr.io/distroless/base:nonroot as openstack-exporter
 


### PR DESCRIPTION
Disabling CGO should make the container image more portable again.
See https://github.com/golang/go/issues/58550


While this is the most lightweight fix, I'd suggest to using Goreleaser also to produce the Docker / container image like we did here https://github.com/inovex/prometheus-libvirt-exporter/blob/1db6fa348b8094ecc92c07f5086005b7dd3cf7a7/.goreleaser.yml#L23.

This avoids the binary build for the container from being different from the standalone one.



Closes #339