### PR TITLE
feat: Basic version of cache mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,9 @@ Flags:
                                  Disable UUID generation for Cinder agents
       --[no-]multi-cloud         Toggle the multiple cloud scraping mode under /probe?cloud=
       --domain-id=DOMAIN-ID      Gather metrics only for the given Domain ID (defaults to all domains)
+      --[no-]cache               Enable Cache mechanism globally
+      --cache-ttl=300s           TTL duration for cache expiry(eg. 10s, 11m, 1h)
+
       --[no-]disable-service.network  
                                  Disable the network service exporter
       --[no-]disable-service.compute  
@@ -232,6 +235,21 @@ openstack_nova_limits_memory_used
 openstack_nova_limits_instances_max
 openstack_nova_limits_instances_used
 ```
+
+### Cache mechanism
+
+Enabling the cache with `--cache` changes the exporter's metric collection and delivery:
+
+- **Background Service:**
+  - Collects metrics at the start and subsequently every half cache TTL.
+  - Updates the cache backend after completing each collection cycle.
+  - Flushes expired cache data every cache TTL.
+
+- **Exporter API:**
+  - Returns no data if the cache is empty or expired.
+  - Retrieves and returns cached data from the backend.
+
+
 
 ## Contributing
 

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -9,7 +9,6 @@
 package cache
 
 import (
-	"fmt"
 	"sync"
 	"time"
 
@@ -24,36 +23,20 @@ type CacheBackend interface {
 	SetCloudCache(string, CloudCache)
 	// Get cache with cloud name.
 	GetCloudCache(string) (CloudCache, bool)
-	// Set cache with service name.
-	SetServiceCache(string, string, ServiceCache)
-	// Get cache with service name.
-	GetServiceCache(string, string) (ServiceCache, bool)
-	// Set cache with metric family name.
-	SetMetricFamilyCache(string, string, string, MetricFamilyCache)
-	// Get cache with metric family name.
-	GetMetricFamilyCache(string, string, string) (MetricFamilyCache, bool)
 	// Flush expired caches based on cloud's update time.
 	FlushExpiredCloudCaches(time.Duration)
-	// Flush all cache data
-	Clear()
 }
 
 // MetricFamily Cache Data
 type MetricFamilyCache struct {
-	Time time.Time
-	MF   *dto.MetricFamily
-}
-
-// Service Cache Data
-type ServiceCache struct {
-	Time               time.Time
-	MetricFamilyCaches map[string]*MetricFamilyCache
+	Service string
+	MF      *dto.MetricFamily
 }
 
 // Cloud Cache Data
 type CloudCache struct {
-	Time          time.Time
-	ServiceCaches map[string]*ServiceCache
+	Time               time.Time
+	MetricFamilyCaches map[string]*MetricFamilyCache
 }
 
 // GetCache return a singleton CacheBackend
@@ -75,7 +58,7 @@ type InMemoryCache struct {
 }
 
 // init ensures the values are not missing in the nested map.
-func (c *InMemoryCache) init(cloud *string, service *string, mfName *string) {
+func (c *InMemoryCache) init(cloud *string) {
 	if c.CloudCaches == nil {
 		c.CloudCaches = make(map[string]*CloudCache)
 	}
@@ -84,7 +67,6 @@ func (c *InMemoryCache) init(cloud *string, service *string, mfName *string) {
 			cloudCache := NewCloudCache()
 			c.CloudCaches[*cloud] = &cloudCache
 		}
-		c.CloudCaches[*cloud].Init(service, mfName)
 	}
 }
 
@@ -100,57 +82,9 @@ func (c *InMemoryCache) GetCloudCache(cloud string) (CloudCache, bool) {
 func (c *InMemoryCache) SetCloudCache(cloud string, data CloudCache) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.init(&cloud, nil, nil)
+	c.init(&cloud)
 	data.Time = time.Now()
 	c.CloudCaches[cloud] = &data
-}
-
-func (c *InMemoryCache) GetServiceCache(cloud string, service string) (ServiceCache, bool) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	if cloudCache, ok := c.CloudCaches[cloud]; ok {
-		if serviceCache, ok := cloudCache.ServiceCaches[service]; ok {
-			return *serviceCache, ok
-		}
-	}
-	return ServiceCache{}, false
-}
-
-func (c *InMemoryCache) SetServiceCache(cloud string, service string, data ServiceCache) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.init(&cloud, nil, nil)
-	data.Time = time.Now()
-	c.CloudCaches[cloud].ServiceCaches[service] = &data
-}
-
-func (c *InMemoryCache) GetMetricFamilyCache(cloud string, service string, mfName string) (MetricFamilyCache, bool) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	if cloudCache, ok := c.CloudCaches[cloud]; ok {
-		if serviceCache, ok := cloudCache.ServiceCaches[service]; ok {
-			if mfCache, ok := serviceCache.MetricFamilyCaches[mfName]; ok {
-				return *mfCache, ok
-			}
-		}
-	}
-	return MetricFamilyCache{}, false
-}
-
-func (c *InMemoryCache) SetMetricFamilyCache(cloud string, service string, mfName string, data MetricFamilyCache) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.init(&cloud, &service, &mfName)
-	data.Time = time.Now()
-	c.CloudCaches[cloud].ServiceCaches[service].MetricFamilyCaches[mfName] = &data
-}
-
-func (c *InMemoryCache) Clear() {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	for key := range c.CloudCaches {
-		delete(c.CloudCaches, key)
-	}
 }
 
 func (c *InMemoryCache) FlushExpiredCloudCaches(ttl time.Duration) {
@@ -159,7 +93,6 @@ func (c *InMemoryCache) FlushExpiredCloudCaches(ttl time.Duration) {
 
 	for key, cloudCache := range c.CloudCaches {
 		expirationTime := cloudCache.Time.Add(ttl)
-		fmt.Println(expirationTime, "\n", time.Now())
 		if time.Now().After(expirationTime) {
 			delete(c.CloudCaches, key)
 		}
@@ -167,37 +100,14 @@ func (c *InMemoryCache) FlushExpiredCloudCaches(ttl time.Duration) {
 }
 
 func NewCloudCache() CloudCache {
-	cloud := CloudCache{}
-	cloud.Init(nil, nil)
+	cloud := CloudCache{
+		Time:               time.Now(),
+		MetricFamilyCaches: make(map[string]*MetricFamilyCache),
+	}
 	return cloud
 }
 
-func (c *CloudCache) Init(service *string, mfName *string) {
-	if c.ServiceCaches == nil {
-		c.ServiceCaches = make(map[string]*ServiceCache)
-	}
-	if c.Time.IsZero() {
-		c.Time = time.Now()
-	}
-	if service != nil {
-		if _, ok := c.ServiceCaches[*service]; !ok {
-			c.ServiceCaches[*service] = &ServiceCache{
-				Time:               time.Now(),
-				MetricFamilyCaches: make(map[string]*MetricFamilyCache),
-			}
-		}
-	}
-	if service != nil && mfName != nil {
-		if _, ok := c.ServiceCaches[*service].MetricFamilyCaches[*mfName]; !ok {
-			c.ServiceCaches[*service].MetricFamilyCaches[*mfName] = &MetricFamilyCache{
-				Time: time.Now(),
-			}
-		}
-	}
-}
-
-func (c *CloudCache) SetMetricFamilyCache(service string, mfName string, data MetricFamilyCache) {
-	c.Init(&service, &mfName)
-	data.Time = time.Now()
-	c.ServiceCaches[service].MetricFamilyCaches[mfName] = &data
+func (c *CloudCache) SetMetricFamilyCache(mfName string, data MetricFamilyCache) {
+	c.Time = time.Now()
+	c.MetricFamilyCaches[mfName] = &data
 }

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -74,7 +74,7 @@ type InMemoryCache struct {
 	CloudCaches map[string]*CloudCache
 }
 
-// init ensures the values are not missing in the nasted map.
+// init ensures the values are not missing in the nested map.
 func (c *InMemoryCache) init(cloud *string, service *string, mfName *string) {
 	if c.CloudCaches == nil {
 		c.CloudCaches = make(map[string]*CloudCache)
@@ -116,6 +116,7 @@ func (c *InMemoryCache) GetCloudCache(cloud string) (CloudCache, bool) {
 func (c *InMemoryCache) SetCloudCache(cloud string, data CloudCache) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	c.init(&cloud, nil, nil)
 	data.Time = time.Now()
 	c.CloudCaches[cloud] = &data
 }
@@ -135,7 +136,6 @@ func (c *InMemoryCache) SetServiceCache(cloud string, service string, data Servi
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.init(&cloud, nil, nil)
-	c.CloudCaches[cloud].Time = time.Now()
 	data.Time = time.Now()
 	c.CloudCaches[cloud].ServiceCaches[service] = &data
 }
@@ -156,9 +156,7 @@ func (c *InMemoryCache) GetMetricFamilyCache(cloud string, service string, mfNam
 func (c *InMemoryCache) SetMetricFamilyCache(cloud string, service string, mfName string, data MetricFamilyCache) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.init(&cloud, &service, nil)
-	c.CloudCaches[cloud].Time = time.Now()
-	c.CloudCaches[cloud].ServiceCaches[service].Time = time.Now()
+	c.init(&cloud, &service, &mfName)
 	data.Time = time.Now()
 	c.CloudCaches[cloud].ServiceCaches[service].MetricFamilyCaches[mfName] = &data
 }

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -1,0 +1,185 @@
+// The cache package provides a concurrency-safe in-memory caching system designed for storing and managing
+// hierarchical cache data related to cloud environments, services, and metric families. The system
+// is designed around a singleton pattern, ensuring only one instance of the cache backend is created and used
+// throughout the application. It supports operations for setting and retrieving cache data at different levels
+// (cloud, service, and metric family), with each level structured to contain relevant data and timestamps for
+// cache validity checks. Additionally, the cache provides functionality to flush data based on age (TTL) and
+// to clear the entire cache.
+
+package cache
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	dto "github.com/prometheus/client_model/go"
+)
+
+var singleCache CacheBackend
+var once sync.Once
+
+type CacheBackend interface {
+	// Set cache with cloud name.
+	SetCloudCache(string, CloudCache)
+	// Get cache with cloud name.
+	GetCloudCache(string) (CloudCache, bool)
+	// Set cache with service name.
+	SetServiceCache(string, string, ServiceCache)
+	// Get cache with service name.
+	GetServiceCache(string, string) (ServiceCache, bool)
+	// Set cache with metric family name.
+	SetMetricFamilyCache(string, string, string, MetricFamilyCache)
+	// Get cache with metric family name.
+	GetMetricFamilyCache(string, string, string) (MetricFamilyCache, bool)
+	// Flush expired caches based on cloud's update time.
+	FlushExpiredCloudCaches(time.Duration)
+	// Flush all cache data
+	Clear()
+}
+
+// MetricFamily Cache Data
+type MetricFamilyCache struct {
+	Time time.Time
+	MF   *dto.MetricFamily
+}
+
+// Service Cache Data
+type ServiceCache struct {
+	Time               time.Time
+	MetricFamilyCaches map[string]*MetricFamilyCache
+}
+
+// Cloud Cache Data
+type CloudCache struct {
+	Time          time.Time
+	ServiceCaches map[string]*ServiceCache
+}
+
+// GetCache return a singleton CacheBackend
+func GetCache() CacheBackend {
+	once.Do(
+		func() {
+			singleCache = &InMemoryCache{
+				CloudCaches: make(map[string]*CloudCache),
+			}
+		},
+	)
+	return singleCache
+}
+
+// InMemoryCache is a in-memory store based CacheBackend implementation.
+type InMemoryCache struct {
+	mu          sync.Mutex
+	CloudCaches map[string]*CloudCache
+}
+
+// init ensures the values are not missing in the nasted map.
+func (c *InMemoryCache) init(cloud *string, service *string, mfName *string) {
+	if c.CloudCaches == nil {
+		c.CloudCaches = make(map[string]*CloudCache)
+	}
+	if cloud != nil {
+		if _, ok := c.CloudCaches[*cloud]; !ok {
+			c.CloudCaches[*cloud] = &CloudCache{
+				Time:          time.Now(),
+				ServiceCaches: make(map[string]*ServiceCache),
+			}
+		}
+	}
+	if cloud != nil && service != nil {
+		if _, ok := c.CloudCaches[*cloud].ServiceCaches[*service]; !ok {
+			c.CloudCaches[*cloud].ServiceCaches[*service] = &ServiceCache{
+				Time:               time.Now(),
+				MetricFamilyCaches: make(map[string]*MetricFamilyCache),
+			}
+		}
+	}
+	if cloud != nil && service != nil && mfName != nil {
+		if _, ok := c.CloudCaches[*cloud].ServiceCaches[*service].MetricFamilyCaches[*mfName]; !ok {
+			c.CloudCaches[*cloud].ServiceCaches[*service].MetricFamilyCaches[*mfName] = &MetricFamilyCache{
+				Time: time.Now(),
+			}
+		}
+	}
+}
+
+func (c *InMemoryCache) GetCloudCache(cloud string) (CloudCache, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if cacheData, exists := c.CloudCaches[cloud]; exists {
+		return *cacheData, exists
+	}
+	return CloudCache{}, false
+}
+
+func (c *InMemoryCache) SetCloudCache(cloud string, data CloudCache) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	data.Time = time.Now()
+	c.CloudCaches[cloud] = &data
+}
+
+func (c *InMemoryCache) GetServiceCache(cloud string, service string) (ServiceCache, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if cloudCache, ok := c.CloudCaches[cloud]; ok {
+		if serviceCache, ok := cloudCache.ServiceCaches[service]; ok {
+			return *serviceCache, ok
+		}
+	}
+	return ServiceCache{}, false
+}
+
+func (c *InMemoryCache) SetServiceCache(cloud string, service string, data ServiceCache) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.init(&cloud, nil, nil)
+	c.CloudCaches[cloud].Time = time.Now()
+	data.Time = time.Now()
+	c.CloudCaches[cloud].ServiceCaches[service] = &data
+}
+
+func (c *InMemoryCache) GetMetricFamilyCache(cloud string, service string, mfName string) (MetricFamilyCache, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if cloudCache, ok := c.CloudCaches[cloud]; ok {
+		if serviceCache, ok := cloudCache.ServiceCaches[service]; ok {
+			if mfCache, ok := serviceCache.MetricFamilyCaches[mfName]; ok {
+				return *mfCache, ok
+			}
+		}
+	}
+	return MetricFamilyCache{}, false
+}
+
+func (c *InMemoryCache) SetMetricFamilyCache(cloud string, service string, mfName string, data MetricFamilyCache) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.init(&cloud, &service, nil)
+	c.CloudCaches[cloud].Time = time.Now()
+	c.CloudCaches[cloud].ServiceCaches[service].Time = time.Now()
+	data.Time = time.Now()
+	c.CloudCaches[cloud].ServiceCaches[service].MetricFamilyCaches[mfName] = &data
+}
+
+func (c *InMemoryCache) Clear() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for key := range c.CloudCaches {
+		delete(c.CloudCaches, key)
+	}
+}
+
+func (c *InMemoryCache) FlushExpiredCloudCaches(ttl time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	for key, cloudCache := range c.CloudCaches {
+		expirationTime := cloudCache.Time.Add(ttl)
+		fmt.Println(expirationTime, "\n", time.Now())
+		if time.Now().After(expirationTime) {
+			delete(c.CloudCaches, key)
+		}
+	}
+}

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -4,24 +4,19 @@ import (
 	"testing"
 
 	"time"
-
-	dto "github.com/prometheus/client_model/go"
 )
 
 // TestSetAndGetCloudCache tests setting and getting cloud cache data.
 func TestInMemoryCachSetAndGetCloudCache(t *testing.T) {
 	cache := GetCache()
-	defer cache.Clear()
+	defer cache.FlushExpiredCloudCaches(1 * time.Nanosecond)
 	cloudName := "testCloud"
 
 	_, exists := cache.GetCloudCache(cloudName)
 	if exists {
 		t.Errorf("Cloud cache not retrieved properly")
 	}
-	cloudData := CloudCache{
-		Time:          time.Now(),
-		ServiceCaches: make(map[string]*ServiceCache),
-	}
+	cloudData := NewCloudCache()
 
 	cache.SetCloudCache(cloudName, cloudData)
 	retrievedCloudData, exists := cache.GetCloudCache(cloudName)
@@ -31,62 +26,11 @@ func TestInMemoryCachSetAndGetCloudCache(t *testing.T) {
 	}
 }
 
-// TestSetAndGetServiceCache tests setting and getting service cache data.
-func TestInMemoryCachSetAndGetServiceCache(t *testing.T) {
-	cache := GetCache()
-	defer cache.Clear()
-	cloudName := "testCloud"
-	serviceName := "testService"
-
-	_, exists := cache.GetServiceCache(cloudName, serviceName)
-	if exists {
-		t.Errorf("Cloud cache not retrieved properly")
-	}
-
-	serviceData := ServiceCache{
-		MetricFamilyCaches: make(map[string]*MetricFamilyCache),
-	}
-
-	cache.SetServiceCache(cloudName, serviceName, serviceData)
-	retrievedServiceData, exists := cache.GetServiceCache(cloudName, serviceName)
-
-	if !exists || retrievedServiceData.Time.IsZero() {
-		t.Errorf("Service cache was not set or retrieved properly")
-	}
-}
-
-// TestSetAndGetMetricFamilyCache tests setting and getting metric family cache data.
-func TestInMemoryCachSetAndGetMetricFamilyCache(t *testing.T) {
-	cache := GetCache()
-	defer cache.Clear()
-	cloudName := "testCloud"
-	serviceName := "testService"
-	mfName := "testMetricFamily"
-
-	_, exists := cache.GetMetricFamilyCache(cloudName, serviceName, mfName)
-	if exists {
-		t.Errorf("Cloud cache not retrieved properly")
-	}
-
-	mfData := MetricFamilyCache{
-		MF: &dto.MetricFamily{},
-	}
-
-	cache.SetMetricFamilyCache(cloudName, serviceName, mfName, mfData)
-	retrievedMfData, exists := cache.GetMetricFamilyCache(cloudName, serviceName, mfName)
-
-	if !exists || retrievedMfData.Time.IsZero() {
-		t.Errorf("Metric family cache was not set or retrieved properly")
-	}
-}
-
 // TestFlushExpiredCloudCaches tests flushing of expired cloud caches.
 func TestInMemoryCacheFlushExpiredCloudCaches(t *testing.T) {
 	cache := GetCache()
-	defer cache.Clear()
-	cloudData := CloudCache{
-		ServiceCaches: make(map[string]*ServiceCache),
-	}
+	defer cache.FlushExpiredCloudCaches(1 * time.Nanosecond)
+	cloudData := NewCloudCache()
 	cloudName := "expiredCloud"
 	cache.SetCloudCache(cloudName, cloudData)
 
@@ -100,14 +44,41 @@ func TestInMemoryCacheFlushExpiredCloudCaches(t *testing.T) {
 
 func TestInMemoryCachInit(t *testing.T) {
 	cache := InMemoryCache{}
-	defer cache.Clear()
+	defer cache.FlushExpiredCloudCaches(1 * time.Nanosecond)
 	cloudName := "testCloud"
-	serviceName := "testService"
-	mfName := "testMetricFamily"
 
-	cache.init(&cloudName, &serviceName, &mfName)
-	_, exists := cache.GetMetricFamilyCache(cloudName, serviceName, mfName)
+	cache.init(&cloudName)
+	_, exists := cache.GetCloudCache(cloudName)
 	if !exists {
 		t.Errorf("Init function not works properly")
+	}
+}
+
+func TestNewCloudCache(t *testing.T) {
+	cloudCache := NewCloudCache()
+	if cloudCache.Time.IsZero() {
+		t.Errorf("Time doesn't been setup properly")
+	}
+	if cloudCache.MetricFamilyCaches == nil {
+		t.Errorf("MetricFamilyCaches doesn't been setup properly")
+	}
+}
+
+func TestCloudCacheSetMetricFamilyCache(t *testing.T) {
+	cache := GetCache()
+	defer cache.FlushExpiredCloudCaches(1 * time.Nanosecond)
+	cloudCache := NewCloudCache()
+
+	serviceName := "testService"
+	mfName := "testMF"
+	cloudCache.SetMetricFamilyCache(
+		mfName, MetricFamilyCache{MF: nil, Service: serviceName},
+	)
+
+	if cloudCache.Time.IsZero() {
+		t.Errorf("Time doesn't been setup properly")
+	}
+	if l := len(cloudCache.MetricFamilyCaches); l != 1 {
+		t.Errorf("SetMetricFamilyCache not set value properly")
 	}
 }

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -1,0 +1,113 @@
+package cache
+
+import (
+	"testing"
+
+	"time"
+
+	dto "github.com/prometheus/client_model/go"
+)
+
+// TestSetAndGetCloudCache tests setting and getting cloud cache data.
+func TestInMemoryCachSetAndGetCloudCache(t *testing.T) {
+	cache := GetCache()
+	defer cache.Clear()
+	cloudName := "testCloud"
+
+	_, exists := cache.GetCloudCache(cloudName)
+	if exists {
+		t.Errorf("Cloud cache not retrieved properly")
+	}
+	cloudData := CloudCache{
+		Time:          time.Now(),
+		ServiceCaches: make(map[string]*ServiceCache),
+	}
+
+	cache.SetCloudCache(cloudName, cloudData)
+	retrievedCloudData, exists := cache.GetCloudCache(cloudName)
+
+	if !exists || retrievedCloudData.Time.IsZero() {
+		t.Errorf("Cloud cache was not set or retrieved properly")
+	}
+}
+
+// TestSetAndGetServiceCache tests setting and getting service cache data.
+func TestInMemoryCachSetAndGetServiceCache(t *testing.T) {
+	cache := GetCache()
+	defer cache.Clear()
+	cloudName := "testCloud"
+	serviceName := "testService"
+
+	_, exists := cache.GetServiceCache(cloudName, serviceName)
+	if exists {
+		t.Errorf("Cloud cache not retrieved properly")
+	}
+
+	serviceData := ServiceCache{
+		MetricFamilyCaches: make(map[string]*MetricFamilyCache),
+	}
+
+	cache.SetServiceCache(cloudName, serviceName, serviceData)
+	retrievedServiceData, exists := cache.GetServiceCache(cloudName, serviceName)
+
+	if !exists || retrievedServiceData.Time.IsZero() {
+		t.Errorf("Service cache was not set or retrieved properly")
+	}
+}
+
+// TestSetAndGetMetricFamilyCache tests setting and getting metric family cache data.
+func TestInMemoryCachSetAndGetMetricFamilyCache(t *testing.T) {
+	cache := GetCache()
+	defer cache.Clear()
+	cloudName := "testCloud"
+	serviceName := "testService"
+	mfName := "testMetricFamily"
+
+	_, exists := cache.GetMetricFamilyCache(cloudName, serviceName, mfName)
+	if exists {
+		t.Errorf("Cloud cache not retrieved properly")
+	}
+
+	mfData := MetricFamilyCache{
+		MF: &dto.MetricFamily{},
+	}
+
+	cache.SetMetricFamilyCache(cloudName, serviceName, mfName, mfData)
+	retrievedMfData, exists := cache.GetMetricFamilyCache(cloudName, serviceName, mfName)
+
+	if !exists || retrievedMfData.Time.IsZero() {
+		t.Errorf("Metric family cache was not set or retrieved properly")
+	}
+}
+
+// TestFlushExpiredCloudCaches tests flushing of expired cloud caches.
+func TestInMemoryCacheFlushExpiredCloudCaches(t *testing.T) {
+	cache := GetCache()
+	defer cache.Clear()
+	cloudData := CloudCache{
+		ServiceCaches: make(map[string]*ServiceCache),
+	}
+	cloudName := "expiredCloud"
+	cache.SetCloudCache(cloudName, cloudData)
+
+	time.Sleep(1 * time.Nanosecond)
+	cache.FlushExpiredCloudCaches(1 * time.Nanosecond)
+
+	if _, exists := cache.GetCloudCache(cloudName); exists {
+		t.Errorf("Expired cloud cache was not flushed")
+	}
+}
+
+func TestInMemoryCachInit(t *testing.T) {
+	cache := InMemoryCache{}
+	defer cache.Clear()
+	cloudName := "testCloud"
+	serviceName := "testService"
+	mfName := "testMetricFamily"
+
+	cache.init(&cloudName, &serviceName, &mfName)
+	_, exists := cache.GetMetricFamilyCache(cloudName, serviceName, mfName)
+	if !exists {
+		t.Errorf("Init function not works properly")
+	}
+}

--- a/cache/utils.go
+++ b/cache/utils.go
@@ -1,0 +1,126 @@
+// Utils provide a series of helper functions.
+
+package cache
+
+import (
+	"bytes"
+	"net/http"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/gophercloud/utils/openstack/clientconfig"
+	"github.com/openstack-exporter/openstack-exporter/exporters"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/prometheus/common/expfmt"
+)
+
+// CollectCache collects the MetricsFamily for required clouds and services and stores in the cache.
+func CollectCache(
+	enableExporterFunc func(string, string, string, []string, string, bool, bool, bool, bool, string, func() (string, error), log.Logger) (*exporters.OpenStackExporter, error), multiCloud bool, services map[string]*bool, prefix, cloud string, disabledMetrics []string, endpointType string, collectTime bool, disableSlowMetrics bool, disableDeprecatedMetrics bool, disableCinderAgentUUID bool, domainID string, uuidGenFunc func() (string, error), logger log.Logger) error {
+	level.Info(logger).Log("msg", "Run collect cache job")
+	cacheBackend := GetCache()
+
+	clouds := []string{}
+
+	if multiCloud {
+		cloudsConfig, err := clientconfig.LoadCloudsYAML()
+		if err != nil {
+			return err
+		}
+		for cloud := range cloudsConfig {
+			clouds = append(clouds, cloud)
+		}
+	}
+	if cloud != "" && !multiCloud {
+		clouds = append(clouds, cloud)
+	}
+
+	enabledServices := []string{}
+	for service, disabled := range services {
+		if !*disabled {
+			enabledServices = append(enabledServices, service)
+		}
+	}
+
+	for _, cloud := range clouds {
+		registry := prometheus.NewPedanticRegistry()
+		for _, service := range enabledServices {
+			level.Info(logger).Log("msg", "Start update cache data", "cloud", cloud, "service", service)
+			exp, err := enableExporterFunc(service, prefix, cloud, disabledMetrics, endpointType, collectTime, disableSlowMetrics, disableDeprecatedMetrics, disableCinderAgentUUID, domainID, nil, logger)
+			if err != nil {
+				// Log error and continue with enabling other exporters
+				level.Error(logger).Log("err", "enabling exporter for service failed", "cloud", cloud, "service", service, "error", err)
+				continue
+			}
+			registry.MustRegister(*exp)
+
+			metricFamilies, err := registry.Gather()
+			if err != nil {
+				level.Error(logger).Log("err", "Create gather failed", "cloud", cloud, "service", service, "error", err)
+				continue
+			}
+			for _, mf := range metricFamilies {
+				cacheBackend.SetMetricFamilyCache(
+					cloud, service, *mf.Name, MetricFamilyCache{
+						MF: mf,
+					},
+				)
+				level.Debug(logger).Log("msg", "Update cache data", "cloud", cloud, "service", service, "MetricsFamily", mf.Name)
+			}
+			level.Info(logger).Log("msg", "Finish update cache data", "cloud", cloud, "service", service)
+		}
+	}
+
+	return nil
+}
+
+// BufferFromCache reads cloud's MetricsFamily data from cache and writes into a buffer.
+func BufferFromCache(cloud string, services []string, logger log.Logger) (bytes.Buffer, error) {
+	cacheBackend := GetCache()
+	var buf bytes.Buffer
+	for _, service := range services {
+		serviceCacheData, exists := cacheBackend.GetServiceCache(cloud, service)
+		if exists {
+			for name, mfCache := range serviceCacheData.MetricFamilyCaches {
+				level.Debug(logger).Log("msg", "Get metric from cache", "cloud", cloud, "service", service, "name", name)
+				_, err := expfmt.MetricFamilyToText(&buf, mfCache.MF)
+				if err != nil {
+					return buf, err
+				}
+			}
+		} else {
+			level.Debug(logger).Log("msg", "Missing service cache", "cloud", cloud, "service", service)
+		}
+	}
+	return buf, nil
+}
+
+// FlushExpiredCloudCaches flush expired caches based on cloud's update time
+func FlushExpiredCloudCaches(ttl time.Duration) {
+	cacheBackend := GetCache()
+	cacheBackend.FlushExpiredCloudCaches(ttl)
+}
+
+// WriteCacheToResponse read cache and write to the connection as part of an HTTP reply.
+func WriteCacheToResponse(w http.ResponseWriter, r *http.Request, cloud string, enabledServices []string, logger log.Logger) error {
+	buf, err := BufferFromCache(cloud, enabledServices, logger)
+	if err != nil {
+		http.Error(w, "Failed to encode metrics", http.StatusInternalServerError)
+	}
+	opts := promhttp.HandlerOpts{}
+
+	// Follow the way how promehttp package set up the contentType
+	var contentType expfmt.Format
+	if opts.EnableOpenMetrics {
+		contentType = expfmt.NegotiateIncludingOpenMetrics(r.Header)
+	} else {
+		contentType = expfmt.Negotiate(r.Header)
+	}
+	w.Header().Set("Context-Type", string(contentType))
+	if _, err = w.Write(buf.Bytes()); err != nil {
+		http.Error(w, "Failed to write cached metrics to response", http.StatusInternalServerError)
+	}
+	return nil
+}

--- a/cache/utils.go
+++ b/cache/utils.go
@@ -113,7 +113,7 @@ func BufferFromCache(cloud string, services []string, logger log.Logger) (bytes.
 	}
 
 	for _, mfCache := range cloudCache.MetricFamilyCaches {
-		if exists := slices.Contains(services, mfCache.Service); !exists {
+		if !slices.Contains(services, mfCache.Service) {
 			continue
 		}
 		if _, err := expfmt.MetricFamilyToText(&buf, mfCache.MF); err != nil {

--- a/cache/utils.go
+++ b/cache/utils.go
@@ -19,7 +19,22 @@ import (
 
 // CollectCache collects the MetricsFamily for required clouds and services and stores in the cache.
 func CollectCache(
-	enableExporterFunc func(string, string, string, []string, string, bool, bool, bool, bool, string, func() (string, error), log.Logger) (*exporters.OpenStackExporter, error), multiCloud bool, services map[string]*bool, prefix, cloud string, disabledMetrics []string, endpointType string, collectTime bool, disableSlowMetrics bool, disableDeprecatedMetrics bool, disableCinderAgentUUID bool, domainID string, uuidGenFunc func() (string, error), logger log.Logger) error {
+	enableExporterFunc func(
+		string, string, string, []string, string, bool, bool, bool, bool, string, func() (string, error), log.Logger,
+	) (*exporters.OpenStackExporter, error),
+	multiCloud bool,
+	services map[string]*bool, prefix,
+	cloud string,
+	disabledMetrics []string,
+	endpointType string,
+	collectTime bool,
+	disableSlowMetrics bool,
+	disableDeprecatedMetrics bool,
+	disableCinderAgentUUID bool,
+	domainID string,
+	uuidGenFunc func() (string, error),
+	logger log.Logger,
+) error {
 	level.Info(logger).Log("msg", "Run collect cache job")
 	cacheBackend := GetCache()
 

--- a/cache/utils_test.go
+++ b/cache/utils_test.go
@@ -65,7 +65,7 @@ func (m *mockOpenStackExporter) MetricIsDisabled(name string) bool {
 
 func TestCollectCache(t *testing.T) {
 	cache := GetCache()
-	defer cache.FlushExpiredCloudCaches(1 * time.Nanosecond)
+	defer newSingleCache()
 
 	multiCloud := false
 	services := make(map[string]*bool)
@@ -113,17 +113,17 @@ func TestCollectCache(t *testing.T) {
 		includeServices = append(includeServices, mf.Service)
 	}
 	if !slices.Contains(includeServices, "service-a") {
-		t.Errorf("Service cache was not set or retrieved properly")
+		t.Errorf("service-a should be included in the cache data")
 	}
 
 	if slices.Contains(includeServices, "service-b") {
-		t.Errorf("Service cache was not set or retrieved properly")
+		t.Errorf("service-b should not be included in the cache data")
 	}
 }
 
 func TestBufferFromCache(t *testing.T) {
 	cache := GetCache()
-	defer cache.FlushExpiredCloudCaches(1 * time.Nanosecond)
+	defer newSingleCache()
 	cloudName := "testCloud"
 	serviceName := "testService"
 
@@ -162,7 +162,7 @@ func TestBufferFromCache(t *testing.T) {
 
 func TestWriteCacheToResponse(t *testing.T) {
 	cache := GetCache()
-	defer cache.FlushExpiredCloudCaches(1 * time.Nanosecond)
+	defer newSingleCache()
 	cloudName := "testCloud"
 	serviceName := "testService"
 
@@ -215,7 +215,7 @@ func TestWriteCacheToResponse(t *testing.T) {
 // TestFlushExpiredCloudCaches tests flushing of expired cloud caches.
 func TestFlushExpiredCloudCaches(t *testing.T) {
 	cache := GetCache()
-	defer cache.FlushExpiredCloudCaches(1 * time.Nanosecond)
+	defer newSingleCache()
 	cloudCache := NewCloudCache()
 	cloudName := "expiredCloud"
 	cache.SetCloudCache(cloudName, cloudCache)

--- a/cache/utils_test.go
+++ b/cache/utils_test.go
@@ -112,11 +112,11 @@ func TestCollectCache(t *testing.T) {
 	for _, mf := range cloudCache.MetricFamilyCaches {
 		includeServices = append(includeServices, mf.Service)
 	}
-	if exists := slices.Contains(includeServices, "service-a"); !exists {
+	if !slices.Contains(includeServices, "service-a") {
 		t.Errorf("Service cache was not set or retrieved properly")
 	}
 
-	if exists := slices.Contains(includeServices, "service-b"); exists {
+	if slices.Contains(includeServices, "service-b") {
 		t.Errorf("Service cache was not set or retrieved properly")
 	}
 }

--- a/main.go
+++ b/main.go
@@ -42,7 +42,7 @@ var (
 	multiCloud               = kingpin.Flag("multi-cloud", "Toggle the multiple cloud scraping mode under /probe?cloud=").Default("false").Bool()
 	domainID                 = kingpin.Flag("domain-id", "Gather metrics only for the given Domain ID (defaults to all domains)").String()
 	cacheEnable              = kingpin.Flag("cache", "Enable Cache globally").Default("false").Bool()
-	cacheTTL                 = kingpin.Flag("cache-ttl", "TTL to expire cache(i.e: 10s, 11m, 1h)").Default("300s").Duration()
+	cacheTTL                 = kingpin.Flag("cache-ttl", "TTL duration for cache expiry(eg. 10s, 11m, 1h)").Default("300s").Duration()
 )
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -5,11 +5,15 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"os/signal"
 	"strings"
+	"syscall"
+	"time"
 
 	kingpin "github.com/alecthomas/kingpin/v2"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	"github.com/openstack-exporter/openstack-exporter/cache"
 	"github.com/openstack-exporter/openstack-exporter/exporters"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -37,6 +41,8 @@ var (
 	cloud                    = kingpin.Arg("cloud", "name or id of the cloud to gather metrics from").String()
 	multiCloud               = kingpin.Flag("multi-cloud", "Toggle the multiple cloud scraping mode under /probe?cloud=").Default("false").Bool()
 	domainID                 = kingpin.Flag("domain-id", "Gather metrics only for the given Domain ID (defaults to all domains)").String()
+	cacheEnable              = kingpin.Flag("cache", "Enable Cache globally").Default("false").Bool()
+	cacheTTL                 = kingpin.Flag("cache-ttl", "TTL to expire cache(i.e: 10s, 11m, 1h)").Default("300s").Duration()
 )
 
 func main() {
@@ -68,6 +74,68 @@ func main() {
 		os.Setenv("OS_CLIENT_CONFIG_FILE", *osClientConfig)
 	}
 
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	errChan := make(chan error, 1)
+
+	// Start the backend service.
+	if *cacheEnable {
+		go cacheBackgroundService(ctx, services, errChan, logger)
+	}
+
+	// Start the HTTP server.
+	go startHTTPServer(ctx, services, toolkitFlags, errChan, logger)
+
+	// Wait for an error from any service or a termination signal.
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+
+	select {
+	case err := <-errChan:
+		level.Error(logger).Log("err", "Shutting down due to error", "err", err)
+		cancel()
+	case <-sigChan:
+		level.Info(logger).Log("msg", "Termination signal received. Shutting down...")
+		cancel()
+	}
+
+}
+
+// cacheBackgroundService runs a background service to collect the metrics and stores in the cache.
+// It collects data every cache-ttl/2 time and flush every cache-ttl time.
+// The cache data will be read by the Prometheus HandleFunc.
+func cacheBackgroundService(ctx context.Context, services map[string]*bool, errChan chan<- error, logger log.Logger) {
+	level.Info(logger).Log("msg", "Start cache background service")
+	collectTicker := time.NewTicker(*cacheTTL / 2)
+	defer collectTicker.Stop()
+	ttlTicker := time.NewTicker(*cacheTTL)
+	defer ttlTicker.Stop()
+
+	// Collect cache data in the beginning.
+	if err := cache.CollectCache(exporters.EnableExporter, *multiCloud, services, *prefix, *cloud, *disabledMetrics, *endpointType, *collectTime, *disableSlowMetrics, *disableDeprecatedMetrics, *disableCinderAgentUUID, *domainID, nil, logger); err != nil {
+		errChan <- err
+		return
+	}
+
+	for {
+		select {
+		case <-collectTicker.C:
+			if err := cache.CollectCache(exporters.EnableExporter, *multiCloud, services, *prefix, *cloud, *disabledMetrics, *endpointType, *collectTime, *disableSlowMetrics, *disableDeprecatedMetrics, *disableCinderAgentUUID, *domainID, nil, logger); err != nil {
+				errChan <- err
+				return
+			}
+		case <-ttlTicker.C:
+			cache.FlushExpiredCloudCaches(*cacheTTL)
+			level.Info(logger).Log("msg", "Cache TTL flush")
+		case <-ctx.Done():
+			level.Info(logger).Log("msg", "Backend service is stopping")
+			return
+		}
+	}
+}
+
+func startHTTPServer(ctx context.Context, services map[string]*bool, toolkitFlags *web.FlagConfig, errChan chan<- error, logger log.Logger) {
 	links := []web.LandingLinks{}
 
 	if *multiCloud {
@@ -111,9 +179,16 @@ func main() {
 	}
 
 	srv := &http.Server{}
-	if err := web.ListenAndServe(srv, toolkitFlags, logger); err != nil {
-		level.Error(logger).Log("err", err)
-		os.Exit(1)
+	go func() {
+		if err := web.ListenAndServe(srv, toolkitFlags, logger); err != nil {
+			level.Error(logger).Log("err", err)
+			os.Exit(1)
+		}
+	}()
+
+	<-ctx.Done()
+	if err := srv.Shutdown(context.Background()); err != nil {
+		level.Error(logger).Log("HTTP server shutdown error", err)
 	}
 }
 
@@ -122,8 +197,6 @@ func probeHandler(services map[string]*bool, logger log.Logger) http.HandlerFunc
 		ctx, cancel := context.WithCancel(r.Context())
 		defer cancel()
 		r = r.WithContext(ctx)
-
-		registry := prometheus.NewPedanticRegistry()
 
 		cloud := r.URL.Query().Get("cloud")
 		if cloud == "" {
@@ -146,9 +219,15 @@ func probeHandler(services map[string]*bool, logger log.Logger) http.HandlerFunc
 
 		excludeServices := strings.Split(r.URL.Query().Get("exclude_services"), ",")
 		enabledServices = exporters.RemoveElements(enabledServices, excludeServices)
-
 		level.Info(logger).Log("msg", "Enabled services", "enabled_services", enabledServices)
 
+		// Get data from cache
+		if *cacheEnable {
+			cache.WriteCacheToResponse(w, r, cloud, enabledServices, logger)
+			return
+		}
+
+		registry := prometheus.NewPedanticRegistry()
 		for _, service := range enabledServices {
 			exp, err := exporters.EnableExporter(service, *prefix, cloud, *disabledMetrics, *endpointType, *collectTime, *disableSlowMetrics, *disableDeprecatedMetrics, *disableCinderAgentUUID, *domainID, nil, logger)
 			if err != nil {
@@ -174,20 +253,31 @@ func metricHandler(services map[string]*bool, logger log.Logger) http.HandlerFun
 			os.Setenv("OS_CLIENT_CONFIG_FILE", *osClientConfig)
 		}
 
-		registry := prometheus.NewPedanticRegistry()
-		enabledExporters := 0
+		enabledServices := []string{}
 		for service, disabled := range services {
 			if !*disabled {
-				exp, err := exporters.EnableExporter(service, *prefix, *cloud, *disabledMetrics, *endpointType, *collectTime, *disableSlowMetrics, *disableDeprecatedMetrics, *disableCinderAgentUUID, *domainID, nil, logger)
-				if err != nil {
-					// Log error and continue with enabling other exporters
-					level.Error(logger).Log("err", "enabling exporter for service failed", "service", service, "error", err)
-					continue
-				}
-				registry.MustRegister(*exp)
-				level.Info(logger).Log("msg", "Enabled exporter for service", "service", service)
-				enabledExporters++
+				enabledServices = append(enabledServices, service)
 			}
+		}
+
+		// Get data from cache
+		if *cacheEnable {
+			cache.WriteCacheToResponse(w, r, *cloud, enabledServices, logger)
+			return
+		}
+
+		registry := prometheus.NewPedanticRegistry()
+		enabledExporters := 0
+		for _, service := range enabledServices {
+			exp, err := exporters.EnableExporter(service, *prefix, *cloud, *disabledMetrics, *endpointType, *collectTime, *disableSlowMetrics, *disableDeprecatedMetrics, *disableCinderAgentUUID, *domainID, nil, logger)
+			if err != nil {
+				// Log error and continue with enabling other exporters
+				level.Error(logger).Log("err", "enabling exporter for service failed", "service", service, "error", err)
+				continue
+			}
+			registry.MustRegister(*exp)
+			level.Info(logger).Log("msg", "Enabled exporter for service", "service", service)
+			enabledExporters++
 		}
 
 		if enabledExporters == 0 {

--- a/main.go
+++ b/main.go
@@ -41,7 +41,7 @@ var (
 	cloud                    = kingpin.Arg("cloud", "name or id of the cloud to gather metrics from").String()
 	multiCloud               = kingpin.Flag("multi-cloud", "Toggle the multiple cloud scraping mode under /probe?cloud=").Default("false").Bool()
 	domainID                 = kingpin.Flag("domain-id", "Gather metrics only for the given Domain ID (defaults to all domains)").String()
-	cacheEnable              = kingpin.Flag("cache", "Enable Cache globally").Default("false").Bool()
+	cacheEnable              = kingpin.Flag("cache", "Enable Cache mechanism globally").Default("false").Bool()
 	cacheTTL                 = kingpin.Flag("cache-ttl", "TTL duration for cache expiry(eg. 10s, 11m, 1h)").Default("300s").Duration()
 )
 

--- a/main.go
+++ b/main.go
@@ -114,6 +114,7 @@ func cacheBackgroundService(ctx context.Context, services map[string]*bool, errC
 
 	// Collect cache data in the beginning.
 	if err := cache.CollectCache(exporters.EnableExporter, *multiCloud, services, *prefix, *cloud, *disabledMetrics, *endpointType, *collectTime, *disableSlowMetrics, *disableDeprecatedMetrics, *disableCinderAgentUUID, *domainID, nil, logger); err != nil {
+		level.Error(logger).Log("err", err)
 		errChan <- err
 		return
 	}

--- a/main.go
+++ b/main.go
@@ -223,7 +223,9 @@ func probeHandler(services map[string]*bool, logger log.Logger) http.HandlerFunc
 
 		// Get data from cache
 		if *cacheEnable {
-			cache.WriteCacheToResponse(w, r, cloud, enabledServices, logger)
+			if err := cache.WriteCacheToResponse(w, r, cloud, enabledServices, logger); err != nil {
+				level.Error(logger).Log("err", "Write cache to response failed", "error", err)
+			}
 			return
 		}
 
@@ -262,7 +264,9 @@ func metricHandler(services map[string]*bool, logger log.Logger) http.HandlerFun
 
 		// Get data from cache
 		if *cacheEnable {
-			cache.WriteCacheToResponse(w, r, *cloud, enabledServices, logger)
+			if err := cache.WriteCacheToResponse(w, r, *cloud, enabledServices, logger); err != nil {
+				level.Error(logger).Log("err", "Write cache to response failed", "error", err)
+			}
 			return
 		}
 

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -3,6 +3,8 @@
 # Register config variables if unset,
 # so users can see available variables by running
 # `sudo snap get golang-openstack-exporter`.
+[ -z "$(snapctl get cache)" ] && snapctl set cache=false
+[ -z "$(snapctl get cache-ttl)" ] && snapctl set cache-ttl=
 [ -z "$(snapctl get cloud)" ] && snapctl set cloud=
 [ -z "$(snapctl get collect-metric-time)" ] && snapctl set collect-metric-time=false
 [ -z "$(snapctl get disable-cinder-agent-uuid)" ] && snapctl set disable-cinder-agent-uuid=false
@@ -32,8 +34,6 @@
 [ -z "$(snapctl get prefix)" ] && snapctl set prefix=
 [ -z "$(snapctl get web.listen-address)" ] && snapctl set web.listen-address=
 [ -z "$(snapctl get web.telemetry-path)" ] && snapctl set web.telemetry-path=
-[ -z "$(snapctl get cache)" ] && snapctl set cache=false
-[ -z "$(snapctl get cache-ttl)" ] && snapctl set cache-ttl=
 
 validate_bool() {
     key="$1"

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -32,6 +32,8 @@
 [ -z "$(snapctl get prefix)" ] && snapctl set prefix=
 [ -z "$(snapctl get web.listen-address)" ] && snapctl set web.listen-address=
 [ -z "$(snapctl get web.telemetry-path)" ] && snapctl set web.telemetry-path=
+[ -z "$(snapctl get cache)" ] && snapctl set cache=false
+[ -z "$(snapctl get cache-ttl)" ] && snapctl set cache-ttl=
 
 validate_bool() {
     key="$1"
@@ -62,3 +64,4 @@ validate_bool disable-service.placement
 validate_bool disable-service.volume
 validate_bool disable-slow-metrics
 validate_bool multi-cloud
+validate_bool cache

--- a/snap/local/service
+++ b/snap/local/service
@@ -57,6 +57,8 @@ add_option web.listen-address
 add_option web.telemetry-path
 add_disable_metrics_options
 add_arg cloud
+add_flag cache
+add_option cache-ttl
 
 # Run the exporter process
 exec "${SNAP}/bin/openstack-exporter" "${args[@]}"

--- a/snap/local/service
+++ b/snap/local/service
@@ -28,6 +28,7 @@ add_arg() {
 }
 
 
+add_flag cache
 add_flag collect-metric-time
 add_flag disable-cinder-agent-uuid
 add_flag disable-deprecated-metrics
@@ -47,6 +48,7 @@ add_flag disable-service.placement
 add_flag disable-service.volume
 add_flag disable-slow-metrics
 add_flag multi-cloud
+add_option cache-ttl
 add_option endpoint-type
 add_option domain-id
 add_option log.format
@@ -57,8 +59,6 @@ add_option web.listen-address
 add_option web.telemetry-path
 add_disable_metrics_options
 add_arg cloud
-add_flag cache
-add_option cache-ttl
 
 # Run the exporter process
 exec "${SNAP}/bin/openstack-exporter" "${args[@]}"


### PR DESCRIPTION
Fix: #351 

- A background service is responsible for gathering metrics and caching them, incorporating a mechanism for Time-to-Live (TTL) expiration.
  - The collection task is scheduled to run at every half interval of the TTL.
- New cache package provides cache backend interface and in-memory store implementation
- metricHandler and probeHandler read caches then return if cache is enabled