### PR TITLE
Add TenantID argument and use it in nova and cinder exporters

### DIFF
--- a/cache/utils.go
+++ b/cache/utils.go
@@ -20,7 +20,7 @@ import (
 // CollectCache collects the MetricsFamily for required clouds and services and stores in the cache.
 func CollectCache(
 	enableExporterFunc func(
-		string, string, string, []string, string, bool, bool, bool, bool, string, func() (string, error), log.Logger,
+		string, string, string, []string, string, bool, bool, bool, bool, string, string, func() (string, error), log.Logger,
 	) (*exporters.OpenStackExporter, error),
 	multiCloud bool,
 	services map[string]*bool, prefix,
@@ -32,6 +32,7 @@ func CollectCache(
 	disableDeprecatedMetrics bool,
 	disableCinderAgentUUID bool,
 	domainID string,
+	tenantID string,
 	uuidGenFunc func() (string, error),
 	logger log.Logger,
 ) error {
@@ -68,7 +69,7 @@ func CollectCache(
 
 		for _, service := range enabledServices {
 			level.Info(logger).Log("msg", "Start collect cache data", "cloud", cloud, "service", service)
-			exp, err := enableExporterFunc(service, prefix, cloud, disabledMetrics, endpointType, collectTime, disableSlowMetrics, disableDeprecatedMetrics, disableCinderAgentUUID, domainID, nil, logger)
+			exp, err := enableExporterFunc(service, prefix, cloud, disabledMetrics, endpointType, collectTime, disableSlowMetrics, disableDeprecatedMetrics, disableCinderAgentUUID, domainID, tenantID, nil, logger)
 			if err != nil {
 				// Log error and continue with enabling other exporters
 				level.Error(logger).Log("err", "enabling exporter for service failed", "cloud", cloud, "service", service, "error", err)

--- a/cache/utils_test.go
+++ b/cache/utils_test.go
@@ -27,6 +27,7 @@ func mockEnableExporter(
 	disableDeprecatedMetrics bool,
 	disableCinderAgentUUID bool,
 	domainID string,
+	tenantID string,
 	uuidGenFunc func() (string, error),
 	logger log.Logger,
 ) (*exporters.OpenStackExporter, error) {
@@ -82,6 +83,7 @@ func TestCollectCache(t *testing.T) {
 	disableDeprecatedMetrics := true
 	disableCinderAgentUUID := false
 	domainID := ""
+	tenantID := ""
 	logger := log.NewLogfmtLogger(os.Stdout)
 
 	if err := CollectCache(
@@ -97,6 +99,7 @@ func TestCollectCache(t *testing.T) {
 		disableDeprecatedMetrics,
 		disableCinderAgentUUID,
 		domainID,
+		tenantID,
 		nil,
 		logger,
 	); err != nil {

--- a/exporters/cinder.go
+++ b/exporters/cinder.go
@@ -97,10 +97,15 @@ func ListVolumesStatus(exporter *BaseOpenStackExporter, ch chan<- prometheus.Met
 	}
 
 	var allVolumes []VolumeWithExt
+	var volumeListOption volumes.ListOpts
 
-	allPagesVolumes, err := volumes.List(exporter.Client, volumes.ListOpts{
-		AllTenants: true,
-	}).AllPages()
+	if exporter.TenantID == "" {
+		volumeListOption = volumes.ListOpts{AllTenants: true}
+	} else {
+		volumeListOption = volumes.ListOpts{TenantID: exporter.TenantID}
+	}
+
+	allPagesVolumes, err := volumes.List(exporter.Client, volumeListOption).AllPages()
 	if err != nil {
 		return err
 	}

--- a/exporters/exporter.go
+++ b/exporters/exporter.go
@@ -41,8 +41,8 @@ type OpenStackExporter interface {
 	MetricIsDisabled(name string) bool
 }
 
-func EnableExporter(service, prefix, cloud string, disabledMetrics []string, endpointType string, collectTime bool, disableSlowMetrics bool, disableDeprecatedMetrics bool, disableCinderAgentUUID bool, domainID string, uuidGenFunc func() (string, error), logger log.Logger) (*OpenStackExporter, error) {
-	exporter, err := NewExporter(service, prefix, cloud, disabledMetrics, endpointType, collectTime, disableSlowMetrics, disableDeprecatedMetrics, disableCinderAgentUUID, domainID, uuidGenFunc, logger)
+func EnableExporter(service, prefix, cloud string, disabledMetrics []string, endpointType string, collectTime bool, disableSlowMetrics bool, disableDeprecatedMetrics bool, disableCinderAgentUUID bool, domainID string, tenantID string, uuidGenFunc func() (string, error), logger log.Logger) (*OpenStackExporter, error) {
+	exporter, err := NewExporter(service, prefix, cloud, disabledMetrics, endpointType, collectTime, disableSlowMetrics, disableDeprecatedMetrics, disableCinderAgentUUID, domainID, tenantID, uuidGenFunc, logger)
 	if err != nil {
 		return nil, err
 	}
@@ -64,6 +64,7 @@ type ExporterConfig struct {
 	DisableDeprecatedMetrics bool
 	DisableCinderAgentUUID   bool
 	DomainID                 string
+	TenantID                 string
 }
 
 type BaseOpenStackExporter struct {
@@ -188,7 +189,7 @@ func (exporter *BaseOpenStackExporter) AddMetric(name string, fn ListFunc, label
 	}
 }
 
-func NewExporter(name, prefix, cloud string, disabledMetrics []string, endpointType string, collectTime bool, disableSlowMetrics bool, disableDeprecatedMetrics bool, disableCinderAgentUUID bool, domainID string, uuidGenFunc func() (string, error), logger log.Logger) (OpenStackExporter, error) {
+func NewExporter(name, prefix, cloud string, disabledMetrics []string, endpointType string, collectTime bool, disableSlowMetrics bool, disableDeprecatedMetrics bool, disableCinderAgentUUID bool, domainID string, tenantID string, uuidGenFunc func() (string, error), logger log.Logger) (OpenStackExporter, error) {
 	var exporter OpenStackExporter
 	var err error
 	var transport *http.Transport
@@ -233,6 +234,7 @@ func NewExporter(name, prefix, cloud string, disabledMetrics []string, endpointT
 		DisableDeprecatedMetrics: disableDeprecatedMetrics,
 		DisableCinderAgentUUID:   disableCinderAgentUUID,
 		DomainID:                 domainID,
+		TenantID:                 tenantID,
 	}
 
 	switch name {

--- a/exporters/exporter_test.go
+++ b/exporters/exporter_test.go
@@ -137,7 +137,7 @@ func (suite *BaseOpenStackTestSuite) SetupTest() {
 	os.Setenv("OS_CLIENT_CONFIG_FILE", path.Join(baseFixturePath, "test_config.yaml"))
 
 	logger := log.NewNopLogger()
-	exporter, err := NewExporter(suite.ServiceName, suite.Prefix, cloudName, []string{}, "public", false, false, false, false, "", func() (string, error) {
+	exporter, err := NewExporter(suite.ServiceName, suite.Prefix, cloudName, []string{}, "public", false, false, false, false, "", "", func() (string, error) {
 		return DEFAULT_UUID, nil
 	}, logger)
 

--- a/exporters/nova.go
+++ b/exporters/nova.go
@@ -297,8 +297,16 @@ func ListAllServers(exporter *BaseOpenStackExporter, ch chan<- prometheus.Metric
 
 	var allServers []ServerWithExt
 	var allFlavors []flavors.Flavor
+	var serverListOption servers.ListOpts
 
-	allPagesServers, err := servers.List(exporter.Client, servers.ListOpts{AllTenants: true}).AllPages()
+	if exporter.TenantID == "" {
+		serverListOption = servers.ListOpts{AllTenants: true}
+	} else {
+		serverListOption = servers.ListOpts{TenantID: exporter.TenantID}
+
+	}
+	allPagesServers, err := servers.List(exporter.Client, serverListOption).AllPages()
+
 	if err != nil {
 		return err
 	}

--- a/main.go
+++ b/main.go
@@ -43,6 +43,7 @@ var (
 	domainID                 = kingpin.Flag("domain-id", "Gather metrics only for the given Domain ID (defaults to all domains)").String()
 	cacheEnable              = kingpin.Flag("cache", "Enable Cache mechanism globally").Default("false").Bool()
 	cacheTTL                 = kingpin.Flag("cache-ttl", "TTL duration for cache expiry(eg. 10s, 11m, 1h)").Default("300s").Duration()
+	tenantID                 = kingpin.Flag("tenant-id", "Gather metrics only for the given Tenant ID (default to all tenants)").String()
 )
 
 func main() {
@@ -113,7 +114,7 @@ func cacheBackgroundService(ctx context.Context, services map[string]*bool, errC
 	defer ttlTicker.Stop()
 
 	// Collect cache data in the beginning.
-	if err := cache.CollectCache(exporters.EnableExporter, *multiCloud, services, *prefix, *cloud, *disabledMetrics, *endpointType, *collectTime, *disableSlowMetrics, *disableDeprecatedMetrics, *disableCinderAgentUUID, *domainID, nil, logger); err != nil {
+	if err := cache.CollectCache(exporters.EnableExporter, *multiCloud, services, *prefix, *cloud, *disabledMetrics, *endpointType, *collectTime, *disableSlowMetrics, *disableDeprecatedMetrics, *disableCinderAgentUUID, *domainID, *tenantID , nil, logger); err != nil {
 		level.Error(logger).Log("err", err)
 		errChan <- err
 		return
@@ -122,7 +123,7 @@ func cacheBackgroundService(ctx context.Context, services map[string]*bool, errC
 	for {
 		select {
 		case <-collectTicker.C:
-			if err := cache.CollectCache(exporters.EnableExporter, *multiCloud, services, *prefix, *cloud, *disabledMetrics, *endpointType, *collectTime, *disableSlowMetrics, *disableDeprecatedMetrics, *disableCinderAgentUUID, *domainID, nil, logger); err != nil {
+			if err := cache.CollectCache(exporters.EnableExporter, *multiCloud, services, *prefix, *cloud, *disabledMetrics, *endpointType, *collectTime, *disableSlowMetrics, *disableDeprecatedMetrics, *disableCinderAgentUUID, *domainID, *tenantID, nil, logger); err != nil {
 				errChan <- err
 				return
 			}
@@ -179,6 +180,10 @@ func startHTTPServer(ctx context.Context, services map[string]*bool, toolkitFlag
 		level.Info(logger).Log("msg", "Gathering metrics for configured domain ID", "domain_id", *domainID)
 	}
 
+	if *tenantID != "" {
+		level.Info(logger).Log("msg", "Gathering metrics for configured tenant ID", "tenant_id", *tenantID)
+	}
+
 	srv := &http.Server{}
 	go func() {
 		if err := web.ListenAndServe(srv, toolkitFlags, logger); err != nil {
@@ -232,7 +237,7 @@ func probeHandler(services map[string]*bool, logger log.Logger) http.HandlerFunc
 
 		registry := prometheus.NewPedanticRegistry()
 		for _, service := range enabledServices {
-			exp, err := exporters.EnableExporter(service, *prefix, cloud, *disabledMetrics, *endpointType, *collectTime, *disableSlowMetrics, *disableDeprecatedMetrics, *disableCinderAgentUUID, *domainID, nil, logger)
+			exp, err := exporters.EnableExporter(service, *prefix, cloud, *disabledMetrics, *endpointType, *collectTime, *disableSlowMetrics, *disableDeprecatedMetrics, *disableCinderAgentUUID, *domainID, *tenantID, nil, logger)
 			if err != nil {
 				level.Error(logger).Log("err", "Enabling exporter for service failed", "service", service, "error", err)
 				continue
@@ -274,7 +279,7 @@ func metricHandler(services map[string]*bool, logger log.Logger) http.HandlerFun
 		registry := prometheus.NewPedanticRegistry()
 		enabledExporters := 0
 		for _, service := range enabledServices {
-			exp, err := exporters.EnableExporter(service, *prefix, *cloud, *disabledMetrics, *endpointType, *collectTime, *disableSlowMetrics, *disableDeprecatedMetrics, *disableCinderAgentUUID, *domainID, nil, logger)
+			exp, err := exporters.EnableExporter(service, *prefix, *cloud, *disabledMetrics, *endpointType, *collectTime, *disableSlowMetrics, *disableDeprecatedMetrics, *disableCinderAgentUUID, *domainID, *tenantID,nil, logger)
 			if err != nil {
 				// Log error and continue with enabling other exporters
 				level.Error(logger).Log("err", "enabling exporter for service failed", "service", service, "error", err)


### PR DESCRIPTION
Hi there,

First of all, thanks for this exporter it is really useful.

As an OpenStack's user (not an admin one), I want to use the exporter on a scoped tenant.

To do so, I've added tenantID argument and use it on the nova and cinder exporters to list all the instances and volumes for a given tenant.

Regards,

