### PR TITLE
Evaluate if os-client-config is accessible early

### DIFF
--- a/main.go
+++ b/main.go
@@ -74,6 +74,11 @@ func main() {
 		os.Setenv("OS_CLIENT_CONFIG_FILE", *osClientConfig)
 	}
 
+	if _, err := os.Stat(*osClientConfig); err != nil {
+		level.Error(logger).Log("err", "Could not read config file", "error", err)
+		os.Exit(1)
+	}
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 


### PR DESCRIPTION
Evaluate if os-client-config is accessible early in the startup. This will only cover the basics such as wrong path or permissions denied.

Closes: #352