### PR TITLE
Added changes to fix versioning code

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,18 @@ WORKDIR /
 
 COPY . .
 
-RUN go mod download && CGO_ENABLED=0 go build -o /openstack-exporter .
+RUN VERSION=$(cat VERSION) && \
+    REVISION=$(git rev-parse --short HEAD) && \
+    BRANCH=$(git rev-parse --abbrev-ref HEAD) && \
+    BUILD_USER="openstack-docker-image-githubci" && \
+    BUILD_DATE=$(date -u '+%Y%m%d-%H:%M:%S') && \
+    LDFLAGS="-X github.com/prometheus/common/version.Version=$VERSION -X github.com/prometheus/common/version.Revision=$REVISION -X github.com/prometheus/common/version.Branch=$BRANCH -X github.com/prometheus/common/version.BuildUser=$BUILD_USER -X github.com/prometheus/common/version.BuildDate=$BUILD_DATE" && \
+    CGO_ENABLED=0 go build -ldflags "$LDFLAGS" -o /openstack-exporter .
 
-FROM gcr.io/distroless/base:nonroot as openstack-exporter
+# Check version works
+RUN /openstack-exporter --version
+
+FROM gcr.io/distroless/base:nonroot AS openstack-exporter
 
 LABEL maintainer="Jorge Niedbalski <j@bearmetal.xyz>"
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,16 @@ The exporter can operate in 2 modes
 You can build it by yourself by cloning this repository and run:
 
 ```sh
-go build -o ./openstack-exporter .
+# LDFLAGS are used to set the version information
+VERSION=$(cat VERSION)
+REVISION=$(git rev-parse --short HEAD)
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+BUILD_USER=$(whoami)
+BUILD_DATE=$(date -u '+%Y%m%d-%H:%M:%S')
+
+LDFLAGS="-X github.com/prometheus/common/version.Version=$VERSION -X github.com/prometheus/common/version.Revision=$REVISION -X github.com/prometheus/common/version.Branch=$BRANCH -X github.com/prometheus/common/version.BuildUser=$BUILD_USER -X github.com/prometheus/common/version.BuildDate=$BUILD_DATE"
+
+go build -ldflags "$LDFLAGS" -o openstack-exporter .
 ```
 Multi cloud mode
 ```sh
@@ -139,7 +148,7 @@ Flags:
                                  Disable the orchestration service exporter
       --[no-]disable-service.placement
                                  Disable the placement service exporter
-      --[no-]disable-service.sharev2  
+      --[no-]disable-service.sharev2
                                  Disable the share service exporter
       --[no-]web.systemd-socket  Use systemd socket activation listeners instead of port listeners (Linux only).
       --web.listen-address=:9180 ...


### PR DESCRIPTION
Closes #426 

```
╭─coder@coder-sharpz7-main ~/projects/openstack-exporter  ‹build-version-metadata*› 
╰─➤  docker build --progress=plain .
#0 building with "default" instance using docker driver
#10 [build 4/5] RUN /openstack-exporter --version
#10 0.324 openstack-exporter, version 1.6.0 (branch: build-version-metadata, revision: add5ae7)
#10 0.324   build user:       openstack-docker-image-githubci
#10 0.324   build date:       20250303-00:41:33
#10 0.324   go version:       go1.22.12
#10 0.324   platform:         linux/amd64
#10 0.324   tags:             unknown
#10 DONE 0.4s
....

We now get full version/build information - from the docker image and with instructions on doing it yourself in the docs.
