### PR TITLE
Add quota max metrics to Cinder exporter

### DIFF
--- a/exporters/cinder_test.go
+++ b/exporters/cinder_test.go
@@ -57,6 +57,12 @@ openstack_cinder_limits_volume_used_gb{tenant="service",tenant_id="3d594eb0f0474
 openstack_cinder_limits_volume_used_gb{tenant="swifttenanttest1",tenant_id="43ebde53fc314b1c9ea2b8c5dc744927"} 0
 openstack_cinder_limits_volume_used_gb{tenant="swifttenanttest2",tenant_id="2db68fed84324f29bb73130c6c2094fb"} 0
 openstack_cinder_limits_volume_used_gb{tenant="swifttenanttest4",tenant_id="4b1eb781a47440acb8af9850103e537f"} 0
+# HELP openstack_cinder_volume_type_quota_gigabytes volume_type_quota_gigabytes
+# TYPE openstack_cinder_volume_type_quota_gigabytes gauge
+openstack_cinder_volume_type_quota_gigabytes{tenant="admin",tenant_id="0c4e939acacf4376bdcd1129f1a054ad",volume_type="tier1"} 1000
+openstack_cinder_volume_type_quota_gigabytes{tenant="admin",tenant_id="0c4e939acacf4376bdcd1129f1a054ad",volume_type="tier2"} 500
+openstack_cinder_volume_type_quota_gigabytes{tenant="demo",tenant_id="0cbd49cbf76d405d9c86562e1d579bd3",volume_type="tier1"} 500
+openstack_cinder_volume_type_quota_gigabytes{tenant="demo",tenant_id="0cbd49cbf76d405d9c86562e1d579bd3",volume_type="tier2"} 200
 # HELP openstack_cinder_pool_capacity_free_gb pool_capacity_free_gb
 # TYPE openstack_cinder_pool_capacity_free_gb gauge
 openstack_cinder_pool_capacity_free_gb{name="i666testhost@FastPool01",vendor_name="EMC",volume_backend_name="VNX_Pool"} 636.316


### PR DESCRIPTION
This Pull Request introduces the following updates to the Cinder exporter:

Added support for exposing volume type quotas: The exporter now retrieves and exposes the maximum volume quotas for different volume types per tenant. This feature is generic and is not tied to a specific volume type. It automatically detects and exposes quotas for all volume types configured in the OpenStack environment, making it more flexible and adaptable to various setups.

Updated cinder.go:

Added a new metric volume_type_quota_gigabytes to track the volume type quota per tenant and volume type.

Modified the ListVolumeLimits function to loop through extra quotas returned by the Cinder API and automatically detect and expose volume type quotas (for example, quotas for tier1-std, tier2-std, etc.), in a generic way that adapts to different volume types without hard-coding specific values.

Updated cinder_test.go:

Added test cases for the new metric openstack_cinder_volume_type_quota_gigabytes, ensuring that the new metric works as expected and is exposed correctly for various tenants and volume types.

Metrics Example: After the change, the following metrics will be exposed:

openstack_cinder_volume_type_quota_gigabytes{tenant="tenant_1", tenant_id="tenant_id_1", volume_type="volume_type_1"} 8192
openstack_cinder_volume_type_quota_gigabytes{tenant="tenant_1", tenant_id="tenant_id_1", volume_type="volume_type_2"} 1024


