### PR TITLE
Reverting Goreleaser Github Action Version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -122,7 +122,7 @@ jobs:
 
       - name: Run Goreleaser
         if: ${{ github.event_name != 'pull_request' }}
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v3
         with:
           version: latest
           args: release --clean


### PR DESCRIPTION
https://github.com/goreleaser/goreleaser-action?tab=readme-ov-file#migrating-from-v3

We can update in a future commit