### PR TITLE
Add nova metadata to labels mapping

### DIFF
--- a/cache/utils.go
+++ b/cache/utils.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/gophercloud/utils/openstack/clientconfig"
 	"github.com/openstack-exporter/openstack-exporter/exporters"
+	"github.com/openstack-exporter/openstack-exporter/utils"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/prometheus/common/expfmt"
@@ -20,7 +21,7 @@ import (
 // CollectCache collects the MetricsFamily for required clouds and services and stores in the cache.
 func CollectCache(
 	enableExporterFunc func(
-		string, string, string, []string, string, bool, bool, bool, bool, string, string, func() (string, error), *slog.Logger,
+		string, string, string, []string, string, bool, bool, bool, bool, string, string, *utils.LabelMappingFlag, func() (string, error), *slog.Logger,
 	) (*exporters.OpenStackExporter, error),
 	multiCloud bool,
 	services map[string]*bool, prefix,
@@ -33,6 +34,7 @@ func CollectCache(
 	disableCinderAgentUUID bool,
 	domainID string,
 	tenantID string,
+	novaMetadataMapping *utils.LabelMappingFlag,
 	uuidGenFunc func() (string, error),
 	logger *slog.Logger,
 ) error {
@@ -69,7 +71,7 @@ func CollectCache(
 
 		for _, service := range enabledServices {
 			logger.Info("Start collect cache data", "cloud", cloud, "service", service)
-			exp, err := enableExporterFunc(service, prefix, cloud, disabledMetrics, endpointType, collectTime, disableSlowMetrics, disableDeprecatedMetrics, disableCinderAgentUUID, domainID, tenantID, nil, logger)
+			exp, err := enableExporterFunc(service, prefix, cloud, disabledMetrics, endpointType, collectTime, disableSlowMetrics, disableDeprecatedMetrics, disableCinderAgentUUID, domainID, tenantID, novaMetadataMapping, nil, logger)
 			if err != nil {
 				// Log error and continue with enabling other exporters
 				logger.Error("enabling exporter for service failed", "cloud", cloud, "service", service, "error", err)

--- a/cache/utils_test.go
+++ b/cache/utils_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/openstack-exporter/openstack-exporter/exporters"
+	"github.com/openstack-exporter/openstack-exporter/utils"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/expfmt"
 	"github.com/stretchr/testify/assert"
@@ -28,6 +29,7 @@ func mockEnableExporter(
 	disableCinderAgentUUID bool,
 	domainID string,
 	tenantID string,
+	novaMetadataMapping *utils.LabelMappingFlag,
 	uuidGenFunc func() (string, error),
 	logger *slog.Logger,
 ) (*exporters.OpenStackExporter, error) {
@@ -84,6 +86,7 @@ func TestCollectCache(t *testing.T) {
 	disableCinderAgentUUID := false
 	domainID := ""
 	tenantID := ""
+	novaMetadataMapping := new(utils.LabelMappingFlag)
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{}))
 
 	if err := CollectCache(
@@ -100,6 +103,7 @@ func TestCollectCache(t *testing.T) {
 		disableCinderAgentUUID,
 		domainID,
 		tenantID,
+		novaMetadataMapping,
 		nil,
 		logger,
 	); err != nil {

--- a/exporters/exporter.go
+++ b/exporters/exporter.go
@@ -16,6 +16,7 @@ import (
 	clientconfigv2 "github.com/gophercloud/utils/v2/openstack/clientconfig"
 	"github.com/hashicorp/go-uuid"
 	"github.com/mitchellh/go-homedir"
+	"github.com/openstack-exporter/openstack-exporter/utils"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -46,8 +47,8 @@ type OpenStackExporter interface {
 	MetricIsDisabled(name string) bool
 }
 
-func EnableExporter(service, prefix, cloud string, disabledMetrics []string, endpointType string, collectTime bool, disableSlowMetrics bool, disableDeprecatedMetrics bool, disableCinderAgentUUID bool, domainID string, tenantID string, uuidGenFunc func() (string, error), logger *slog.Logger) (*OpenStackExporter, error) {
-	exporter, err := NewExporter(service, prefix, cloud, disabledMetrics, endpointType, collectTime, disableSlowMetrics, disableDeprecatedMetrics, disableCinderAgentUUID, domainID, tenantID, uuidGenFunc, logger)
+func EnableExporter(service, prefix, cloud string, disabledMetrics []string, endpointType string, collectTime bool, disableSlowMetrics bool, disableDeprecatedMetrics bool, disableCinderAgentUUID bool, domainID string, tenantID string, novaMetadataMapping *utils.LabelMappingFlag, uuidGenFunc func() (string, error), logger *slog.Logger) (*OpenStackExporter, error) {
+	exporter, err := NewExporter(service, prefix, cloud, disabledMetrics, endpointType, collectTime, disableSlowMetrics, disableDeprecatedMetrics, disableCinderAgentUUID, domainID, tenantID, novaMetadataMapping, uuidGenFunc, logger)
 	if err != nil {
 		return nil, err
 	}
@@ -71,6 +72,7 @@ type ExporterConfig struct {
 	DisableCinderAgentUUID   bool
 	DomainID                 string
 	TenantID                 string
+	NovaMetadataMapping      *utils.LabelMappingFlag
 }
 
 type BaseOpenStackExporter struct {
@@ -229,7 +231,7 @@ func pathOrContents(poc string) ([]byte, bool, error) {
 	return []byte(poc), false, nil
 }
 
-func NewExporter(name, prefix, cloud string, disabledMetrics []string, endpointType string, collectTime bool, disableSlowMetrics bool, disableDeprecatedMetrics bool, disableCinderAgentUUID bool, domainID string, tenantID string, uuidGenFunc func() (string, error), logger *slog.Logger) (OpenStackExporter, error) {
+func NewExporter(name, prefix, cloud string, disabledMetrics []string, endpointType string, collectTime bool, disableSlowMetrics bool, disableDeprecatedMetrics bool, disableCinderAgentUUID bool, domainID string, tenantID string, novaMetadataMapping *utils.LabelMappingFlag, uuidGenFunc func() (string, error), logger *slog.Logger) (OpenStackExporter, error) {
 	var exporter OpenStackExporter
 	var err error
 	var transport *http.Transport
@@ -305,6 +307,7 @@ func NewExporter(name, prefix, cloud string, disabledMetrics []string, endpointT
 		DisableCinderAgentUUID:   disableCinderAgentUUID,
 		DomainID:                 domainID,
 		TenantID:                 tenantID,
+		NovaMetadataMapping:      novaMetadataMapping,
 	}
 
 	switch name {

--- a/exporters/exporter_test.go
+++ b/exporters/exporter_test.go
@@ -11,6 +11,7 @@ import (
 	"log/slog"
 
 	"github.com/jarcoal/httpmock"
+	"github.com/openstack-exporter/openstack-exporter/utils"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -146,8 +147,9 @@ func (suite *BaseOpenStackTestSuite) SetupTest() {
 
 	os.Setenv("OS_CLIENT_CONFIG_FILE", path.Join(baseFixturePath, "test_config.yaml"))
 
+	novaMatadataMapping := new(utils.LabelMappingFlag)
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{}))
-	exporter, err := NewExporter(suite.ServiceName, suite.Prefix, cloudName, []string{}, "public", false, false, false, false, "", "", func() (string, error) {
+	exporter, err := NewExporter(suite.ServiceName, suite.Prefix, cloudName, []string{}, "public", false, false, false, false, "", "", novaMatadataMapping, func() (string, error) {
 		return DEFAULT_UUID, nil
 	}, logger)
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openstack-exporter/openstack-exporter
 
-go 1.23.0
+go 1.24.0
 
 toolchain go1.24.4
 

--- a/main.go
+++ b/main.go
@@ -120,7 +120,7 @@ func cacheBackgroundService(ctx context.Context, services map[string]*bool, errC
 	defer ttlTicker.Stop()
 
 	// Collect cache data in the beginning.
-	if err := cache.CollectCache(exporters.EnableExporter, *multiCloud, services, *prefix, *cloud, *disabledMetrics, *endpointType, *collectTime, *disableSlowMetrics, *disableDeprecatedMetrics, *disableCinderAgentUUID, *domainID, *tenantID, nil, logger); err != nil {
+	if err := cache.CollectCache(exporters.EnableExporter, *multiCloud, services, *prefix, *cloud, *disabledMetrics, *endpointType, *collectTime, *disableSlowMetrics, *disableDeprecatedMetrics, *disableCinderAgentUUID, *domainID, *tenantID, novaMetadataMapping, nil, logger); err != nil {
 		logger.Error("Failed to collect from cache", "err", err)
 		errChan <- err
 		return
@@ -129,7 +129,7 @@ func cacheBackgroundService(ctx context.Context, services map[string]*bool, errC
 	for {
 		select {
 		case <-collectTicker.C:
-			if err := cache.CollectCache(exporters.EnableExporter, *multiCloud, services, *prefix, *cloud, *disabledMetrics, *endpointType, *collectTime, *disableSlowMetrics, *disableDeprecatedMetrics, *disableCinderAgentUUID, *domainID, *tenantID, nil, logger); err != nil {
+			if err := cache.CollectCache(exporters.EnableExporter, *multiCloud, services, *prefix, *cloud, *disabledMetrics, *endpointType, *collectTime, *disableSlowMetrics, *disableDeprecatedMetrics, *disableCinderAgentUUID, *domainID, *tenantID, novaMetadataMapping, nil, logger); err != nil {
 				errChan <- err
 				return
 			}
@@ -243,7 +243,7 @@ func probeHandler(services map[string]*bool, logger *slog.Logger) http.HandlerFu
 
 		registry := prometheus.NewPedanticRegistry()
 		for _, service := range enabledServices {
-			exp, err := exporters.EnableExporter(service, *prefix, cloud, *disabledMetrics, *endpointType, *collectTime, *disableSlowMetrics, *disableDeprecatedMetrics, *disableCinderAgentUUID, *domainID, *tenantID, nil, logger)
+			exp, err := exporters.EnableExporter(service, *prefix, cloud, *disabledMetrics, *endpointType, *collectTime, *disableSlowMetrics, *disableDeprecatedMetrics, *disableCinderAgentUUID, *domainID, *tenantID, novaMetadataMapping, nil, logger)
 			if err != nil {
 				logger.Error("Enabling exporter for service failed", "service", service, "error", err)
 				continue
@@ -285,7 +285,7 @@ func metricHandler(services map[string]*bool, logger *slog.Logger) http.HandlerF
 		registry := prometheus.NewPedanticRegistry()
 		enabledExporters := 0
 		for _, service := range enabledServices {
-			exp, err := exporters.EnableExporter(service, *prefix, *cloud, *disabledMetrics, *endpointType, *collectTime, *disableSlowMetrics, *disableDeprecatedMetrics, *disableCinderAgentUUID, *domainID, *tenantID, nil, logger)
+			exp, err := exporters.EnableExporter(service, *prefix, *cloud, *disabledMetrics, *endpointType, *collectTime, *disableSlowMetrics, *disableDeprecatedMetrics, *disableCinderAgentUUID, *domainID, *tenantID, novaMetadataMapping, nil, logger)
 			if err != nil {
 				// Log error and continue with enabling other exporters
 				logger.Error("enabling exporter for service failed", "service", service, "error", err)

--- a/main.go
+++ b/main.go
@@ -15,6 +15,7 @@ import (
 	kingpin "github.com/alecthomas/kingpin/v2"
 	"github.com/openstack-exporter/openstack-exporter/cache"
 	"github.com/openstack-exporter/openstack-exporter/exporters"
+	"github.com/openstack-exporter/openstack-exporter/utils"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/prometheus/common/promslog"
@@ -44,6 +45,7 @@ var (
 	cacheEnable              = kingpin.Flag("cache", "Enable Cache mechanism globally").Default("false").Bool()
 	cacheTTL                 = kingpin.Flag("cache-ttl", "TTL duration for cache expiry(eg. 10s, 11m, 1h)").Default("300s").Duration()
 	tenantID                 = kingpin.Flag("tenant-id", "Gather metrics only for the given Tenant ID (default to all tenants)").String()
+	novaMetadataMapping      = utils.LabelMapping(kingpin.Flag("nova.metadata-extra-labels", "Map provided server metadata keys to labels in openstack_nova_server_status metric").PlaceHolder("LABEL=KEY,KEY").Default(""))
 )
 
 func main() {

--- a/utils/kingpin_parser.go
+++ b/utils/kingpin_parser.go
@@ -1,0 +1,98 @@
+package utils
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"slices"
+	"strings"
+
+	"github.com/alecthomas/kingpin/v2"
+)
+
+var (
+	ErrLabelDup  = errors.New("duplicate label")
+	ErrLabelName = errors.New("bad label name")
+)
+
+// NOTE: unfortunately go's regexp do not support group inverse match
+var labelNameConstraintRe = regexp.MustCompile(`^([^_0-9][^_][a-zA-Z]|(?:_)[a-zA-Z0-9]|[a-zA-Z])[a-zA-Z0-9_]*$`)
+
+// LabelMappingFlag parse server metadata to label kingpin option
+//
+// Supported formats:
+// - `label=key` - map metadata *key* value to *label*;
+// - `key` - same as above if *label* equal to *key*.
+//
+// Accept multiple mappings separated by comma (',').
+// One metadata key may be mapped into multiple labels, but not vice versa.
+type LabelMappingFlag struct {
+	Labels []string
+	Keys   []string
+}
+
+func (s *LabelMappingFlag) Set(value string) error {
+	if s.Labels == nil {
+		s.Labels = make([]string, 0)
+	}
+	if s.Keys == nil {
+		s.Keys = make([]string, 0)
+	}
+
+	if len(value) == 0 {
+		return nil
+	}
+
+	for kv := range strings.SplitSeq(value, ",") {
+		label, key, ok := strings.Cut(kv, "=")
+		if !ok {
+			key = label
+		}
+
+		if slices.Contains(s.Labels, label) {
+			return fmt.Errorf("%w: %s", ErrLabelDup, label)
+		}
+		if !labelNameConstraintRe.MatchString(label) {
+			return fmt.Errorf("%w: %s", ErrLabelName, label)
+		}
+
+		s.Labels = append(s.Labels, label)
+		s.Keys = append(s.Keys, key)
+	}
+
+	return nil
+}
+
+func (s *LabelMappingFlag) String() string {
+
+	buf := make([]string, 0, len(s.Labels))
+	for i := range s.Labels {
+		label, key := s.Labels[i], s.Keys[i]
+		if label != key {
+			buf = append(buf, strings.Join([]string{label, key}, "="))
+		} else {
+			buf = append(buf, label)
+		}
+	}
+
+	return strings.Join(buf, ",")
+}
+
+func (s *LabelMappingFlag) IsCumulative() bool {
+	return true
+}
+
+func (s *LabelMappingFlag) Extract(m map[string]string) []string {
+	ret := make([]string, 0, len(s.Keys))
+	for _, key := range s.Keys {
+		ret = append(ret, m[key])
+	}
+
+	return ret
+}
+
+func LabelMapping(s kingpin.Settings) *LabelMappingFlag {
+	ret := new(LabelMappingFlag)
+	s.SetValue(ret)
+	return ret
+}

--- a/utils/kingpin_parser_test.go
+++ b/utils/kingpin_parser_test.go
@@ -1,0 +1,68 @@
+package utils
+
+import (
+	"fmt"
+	"testing"
+
+	assertpkg "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLabelMappingFlag_Set(t *testing.T) {
+	assert := assertpkg.New(t)
+
+	flg := new(LabelMappingFlag)
+
+	// 1. Basic parsing
+	err := flg.Set("server_group=group,severity,foobar=baz")
+	assert.NoError(err)
+	assert.Len(flg.Labels, 3)
+	assert.Len(flg.Keys, 3)
+	assert.Equal([]string{"server_group", "severity", "foobar"}, flg.Labels)
+	assert.Equal([]string{"group", "severity", "baz"}, flg.Keys)
+
+	// 2. Test cumulative
+	err = flg.Set("test,notify_team=quux")
+	assert.NoError(err)
+	assert.Len(flg.Labels, 5)
+	assert.Len(flg.Keys, 5)
+	assert.Equal([]string{"server_group", "severity", "foobar", "test", "notify_team"}, flg.Labels)
+	assert.Equal([]string{"group", "severity", "baz", "test", "quux"}, flg.Keys)
+
+	// 3. Forbid label duplication
+	err = flg.Set("test2,severity")
+	assert.ErrorIs(err, ErrLabelDup)
+	assert.EqualError(err, "duplicate label: severity")
+
+	// 4. Check label name comply with prometheus requirements
+	for _, badLabel := range []string{"Test Label", "__some_label", "1ee7"} {
+		t.Run(badLabel, func(t *testing.T) {
+			err = flg.Set(badLabel)
+			assertpkg.ErrorIs(t, err, ErrLabelName)
+			assertpkg.EqualError(t, err, fmt.Sprintf("bad label name: %s", badLabel))
+		})
+	}
+}
+
+func TestLabelMappingFlag_Extract(t *testing.T) {
+	flg := new(LabelMappingFlag)
+	err := flg.Set("server_group=group,severity,foobar=baz")
+	require.NoError(t, err)
+
+	testCases := []struct {
+		name     string
+		metadata map[string]string
+		expected []string
+	}{
+		{"all", map[string]string{"group": "grp1", "severity": "critical", "baz": "lorem-ipsum"}, []string{"grp1", "critical", "lorem-ipsum"}},
+		{"some", map[string]string{"group": "grp2"}, []string{"grp2", "", ""}},
+		{"nil", nil, []string{"", "", ""}},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			obtained := flg.Extract(tc.metadata)
+			assertpkg.Equal(t, tc.expected, obtained)
+		})
+	}
+}


### PR DESCRIPTION
It's alternative to #392 - but carry only preconfigured set of labels, which helps to reduce label index cardinality.

Basically that adds `--nova.metadata-extra-labels` option, which controls what metadata keys should be translated into a label.
Format is `label_name=metadata_key`, or just `metadata_key` when both sides are equal.
Option is repeatable, so you can provide multiple mappings that way, or just use `,` to combine a list.