### PR TITLE
Ironic Fixes in CI / moving more in line with Gophercloud

### DIFF
--- a/.github/workflows/integration-baremetal.yml
+++ b/.github/workflows/integration-baremetal.yml
@@ -21,10 +21,25 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Configure apt network retries
+        run: |
+          sudo tee /etc/apt/apt.conf.d/99-ci-network-timeouts >/dev/null <<'EOF'
+          Acquire::Retries "5";
+          Acquire::http::Timeout "30";
+          Acquire::https::Timeout "30";
+          EOF
+
       - name: Work around broken dnsmasq
         run: sudo apt-get purge -y dnsmasq-base
 
+      - name: Preinstall Ironic VM dependencies
+        timeout-minutes: 20
+        run: |
+          sudo apt-get update
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y qemu-system-misc
+
       - name: Deploy devstack
+        timeout-minutes: 120
         uses: gophercloud/devstack-action@60ca1042045c0c9e3e001c64575d381654ffcba1 # v0.19
         with:
           branch: ${{ matrix.openstack_version }}

--- a/.github/workflows/integration-baremetal.yml
+++ b/.github/workflows/integration-baremetal.yml
@@ -62,7 +62,6 @@ jobs:
           enabled_services: "ir-api,ir-cond,s-account,s-container,s-object,s-proxy,q-svc,q-agt,q-dhcp,q-l3,q-meta,-cinder,-c-sch,-c-api,-c-vol,-c-bak,-ovn,-ovn-controller,-ovn-northd,-q-ovn-metadata-agent,openstack-cli-server"
 
       - name: Checkout go
-        if: ${{ fromJSON(steps.changed-files.outputs.matches) }}
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: 'go.mod'

--- a/.github/workflows/integration-baremetal.yml
+++ b/.github/workflows/integration-baremetal.yml
@@ -21,6 +21,7 @@ jobs:
         with:
           persist-credentials: false
 
+      # NOTE(Sharpz7): Should be reverted + tested before 2027-05-06
       - name: Configure apt mirror and network retries
         run: |
           sudo sed -i 's#http://azure.archive.ubuntu.com/ubuntu#http://archive.ubuntu.com/ubuntu#g' /etc/apt/apt-mirrors.txt

--- a/.github/workflows/integration-baremetal.yml
+++ b/.github/workflows/integration-baremetal.yml
@@ -12,23 +12,24 @@ jobs:
           - name: "master"
             openstack_version: "master"
             ubuntu_version: "24.04"
-            additional_services: "openstack-cli-server"
+
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Deploy OpenStack ${{ matrix.name }} with Ironic and run baremetal acceptance tests
     steps:
       - name: Checkout Gophercloud
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
       - name: Work around broken dnsmasq
         run: sudo apt-get purge -y dnsmasq-base
+
       - name: Deploy devstack
-        uses: gophercloud/devstack-action@60ca1042045c0c9e3e001c64575d381654ffcba1
+        uses: gophercloud/devstack-action@60ca1042045c0c9e3e001c64575d381654ffcba1 # v0.19
         with:
           branch: ${{ matrix.openstack_version }}
           conf_overrides: |
-            # pyghmi is not mirrored on github
-            PYGHMI_REPO=https://opendev.org/x/pyghmi
             enable_plugin ironic https://github.com/openstack/ironic ${{ matrix.openstack_version }}
-            LIBS_FROM_GIT=pyghmi,virtualbmc
             FORCE_CONFIG_DRIVE=True
             Q_AGENT=openvswitch
             Q_ML2_TENANT_NETWORK_TYPE=vxlan
@@ -58,23 +59,29 @@ jobs:
             IRONIC_ENABLED_DEPLOY_INTERFACES=direct,fake
             SWIFT_ENABLE_TEMPURLS=True
             SWIFT_TEMPURL_KEY=secretkey
-          enabled_services: "ir-api,ir-cond,s-account,s-container,s-object,s-proxy,q-svc,q-agt,q-dhcp,q-l3,q-meta,-cinder,-c-sch,-c-api,-c-vol,-c-bak,-ovn,-ovn-controller,-ovn-northd,-q-ovn-metadata-agent,${{ matrix.additional_services }}"
+          enabled_services: "ir-api,ir-cond,s-account,s-container,s-object,s-proxy,q-svc,q-agt,q-dhcp,q-l3,q-meta,-cinder,-c-sch,-c-api,-c-vol,-c-bak,-ovn,-ovn-controller,-ovn-northd,-q-ovn-metadata-agent,openstack-cli-server"
 
-      - uses: actions/setup-go@v6
+      - name: Checkout go
+        if: ${{ fromJSON(steps.changed-files.outputs.matches) }}
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version-file: go.mod
+          go-version-file: 'go.mod'
+          cache: true
+
       - name: Run Openstack Integration Tests
         run: ./script/integration-suites/baremetal
         env:
           DEVSTACK_PATH: ${{ github.workspace }}/devstack
           PACKAGE: "./integration/..."
           OS_BRANCH: ${{ matrix.openstack_version }}
+
       - name: Generate logs on failure
         run: ./script/collectlogs
         if: failure()
+
       - name: Upload logs artifacts on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: integration-baremetal-${{ matrix.name }}-${{ github.run_id }}
           path: /tmp/devstack-logs/*

--- a/.github/workflows/integration-baremetal.yml
+++ b/.github/workflows/integration-baremetal.yml
@@ -23,18 +23,7 @@ jobs:
 
       - name: Configure apt mirror and network retries
         run: |
-          mirror_url="http://archive.ubuntu.com/ubuntu"
-          for apt_file in \
-            /etc/apt/apt-mirrors.txt \
-            /etc/apt/sources.list \
-            /etc/apt/sources.list.d/*.list \
-            /etc/apt/sources.list.d/*.sources; do
-            if [ -f "${apt_file}" ]; then
-              sudo sed -i -E "s#http://[a-z0-9.-]*archive\.ubuntu\.com/ubuntu/?#${mirror_url}#g" "${apt_file}"
-            fi
-          done
-          grep -R "ubuntu.com/ubuntu" /etc/apt/apt-mirrors.txt /etc/apt/sources.list /etc/apt/sources.list.d || true
-
+          sudo sed -i 's#http://azure.archive.ubuntu.com/ubuntu#http://archive.ubuntu.com/ubuntu#g' /etc/apt/apt-mirrors.txt
           sudo tee /etc/apt/apt.conf.d/99-ci-network-timeouts >/dev/null <<'EOF'
           Acquire::Retries "5";
           Acquire::http::Timeout "30";
@@ -43,12 +32,6 @@ jobs:
 
       - name: Work around broken dnsmasq
         run: sudo apt-get purge -y dnsmasq-base
-
-      - name: Preinstall Ironic VM dependencies
-        timeout-minutes: 20
-        run: |
-          sudo apt-get update
-          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y qemu-system-misc
 
       - name: Deploy devstack
         timeout-minutes: 120

--- a/.github/workflows/integration-baremetal.yml
+++ b/.github/workflows/integration-baremetal.yml
@@ -21,8 +21,20 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Configure apt network retries
+      - name: Configure apt mirror and network retries
         run: |
+          mirror_url="http://archive.ubuntu.com/ubuntu"
+          for apt_file in \
+            /etc/apt/apt-mirrors.txt \
+            /etc/apt/sources.list \
+            /etc/apt/sources.list.d/*.list \
+            /etc/apt/sources.list.d/*.sources; do
+            if [ -f "${apt_file}" ]; then
+              sudo sed -i -E "s#http://[a-z0-9.-]*archive\.ubuntu\.com/ubuntu/?#${mirror_url}#g" "${apt_file}"
+            fi
+          done
+          grep -R "ubuntu.com/ubuntu" /etc/apt/apt-mirrors.txt /etc/apt/sources.list /etc/apt/sources.list.d || true
+
           sudo tee /etc/apt/apt.conf.d/99-ci-network-timeouts >/dev/null <<'EOF'
           Acquire::Retries "5";
           Acquire::http::Timeout "30";


### PR DESCRIPTION
Based on https://github.com/gophercloud/gophercloud/blob/main/.github/workflows/functional-baremetal.yaml#L65

A fix with the azure mirror and the `qemu-system-misc` package, plus changes to put us more in line with the YAML from gophercloud. This will be done in the other services as part of https://github.com/openstack-exporter/openstack-exporter/issues/548