### PR TITLE
Handle removed Nova security groups endpoint

### DIFF
--- a/exporters/nova.go
+++ b/exporters/nova.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"reflect"
 	"slices"
 	"strings"
@@ -338,6 +339,12 @@ func ListComputeSecGroups(ctx context.Context, exporter *BaseOpenStackExporter, 
 
 	allPagesSecurityGroups, err := secgroups.List(exporter.ClientV2).AllPages(ctx)
 	if err != nil {
+		// Nova removed the legacy os-security-groups endpoint. Neutron still
+		// provides security-group metrics, so do not fail the whole exporter
+		// when a modern Nova deployment returns 404 for this optional metric.
+		if gophercloud.ResponseCodeIs(err, http.StatusNotFound) {
+			return nil
+		}
 		return err
 	}
 

--- a/exporters/nova_test.go
+++ b/exporters/nova_test.go
@@ -1,14 +1,26 @@
 package exporters
 
 import (
+	"context"
+	"net/http"
 	"strings"
 
+	"github.com/jarcoal/httpmock"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 )
 
 type NovaTestSuite struct {
 	BaseOpenStackTestSuite
+}
+
+func (suite *NovaTestSuite) TestSecurityGroupsEndpointNotFound() {
+	httpmock.RegisterResponder("GET", suite.MakeURL("/compute/os-security-groups", ""), httpmock.NewStringResponder(http.StatusNotFound, ""))
+
+	exporter := (*suite.Exporter).(*NovaExporter)
+	err := ListComputeSecGroups(context.Background(), &exporter.BaseOpenStackExporter, make(chan prometheus.Metric, 1))
+	assert.NoError(suite.T(), err)
 }
 
 var novaExpectedUp = `


### PR DESCRIPTION
## What changed

Treat a 404 from Nova legacy `os-security-groups` as an unavailable optional metric instead of a failed collection.

## Why

Modern Nova deployments no longer expose this endpoint. Neutron continues to provide security-group metrics.

## Validation

- `go test ./exporters`

Fixes #470.