### PR TITLE
Export server addresses from Nova response

### DIFF
--- a/exporters/nova.go
+++ b/exporters/nova.go
@@ -2,6 +2,7 @@ package exporters
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"reflect"
@@ -413,17 +414,18 @@ func ListAllServers(ctx context.Context, exporter *BaseOpenStackExporter, ch cha
 	// Server status metrics
 	if !exporter.MetricIsDisabled("server_status") {
 		for _, server := range allServers {
+			addressIPv4, addressIPv6 := serverAddresses(server)
 			labelValues := func() []string {
 				if flavorIDMapper == nil {
 					return []string{
 						server.ID, server.Status, server.Name, server.TenantID,
-						server.UserID, server.AccessIPv4, server.AccessIPv6, server.HostID, server.HypervisorHostname, server.ID,
+						server.UserID, addressIPv4, addressIPv6, server.HostID, server.HypervisorHostname, server.ID,
 						server.AvailabilityZone, fmt.Sprintf("%v", server.Flavor["id"]), server.InstanceName,
 					}
 				}
 				return []string{
 					server.ID, server.Status, server.Name, server.TenantID,
-					server.UserID, server.AccessIPv4, server.AccessIPv6, server.HostID, server.HypervisorHostname, server.ID,
+					server.UserID, addressIPv4, addressIPv6, server.HostID, server.HypervisorHostname, server.ID,
 					server.AvailabilityZone, flavorIDMapper.Search(server.Flavor["original_name"]), server.InstanceName,
 				}
 			}()
@@ -434,6 +436,39 @@ func ListAllServers(ctx context.Context, exporter *BaseOpenStackExporter, ch cha
 		}
 	}
 	return nil
+}
+
+// serverAddresses falls back to the standard Nova addresses map when the
+// optional accessIPv4/accessIPv6 fields are not populated.
+func serverAddresses(server servers.Server) (string, string) {
+	ipv4, ipv6 := server.AccessIPv4, server.AccessIPv6
+	if ipv4 != "" && ipv6 != "" {
+		return ipv4, ipv6
+	}
+
+	for _, rawAddresses := range server.Addresses {
+		data, err := json.Marshal(rawAddresses)
+		if err != nil {
+			continue
+		}
+		var addresses []struct {
+			Address string `json:"addr"`
+			Version int    `json:"version"`
+		}
+		if json.Unmarshal(data, &addresses) != nil {
+			continue
+		}
+		for _, address := range addresses {
+			if address.Version == 4 && ipv4 == "" {
+				ipv4 = address.Address
+			}
+			if address.Version == 6 && ipv6 == "" {
+				ipv6 = address.Address
+			}
+		}
+	}
+
+	return ipv4, ipv6
 }
 
 type novaRunningVMLabels struct {

--- a/exporters/nova_test.go
+++ b/exporters/nova_test.go
@@ -3,12 +3,26 @@ package exporters
 import (
 	"strings"
 
+	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/servers"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 )
 
 type NovaTestSuite struct {
 	BaseOpenStackTestSuite
+}
+
+func (suite *NovaTestSuite) TestServerAddressesFallback() {
+	server := servers.Server{Addresses: map[string]any{
+		"private": []any{
+			map[string]any{"addr": "192.0.2.10", "version": 4},
+			map[string]any{"addr": "2001:db8::10", "version": 6},
+		},
+	}}
+
+	ipv4, ipv6 := serverAddresses(server)
+	assert.Equal(suite.T(), "192.0.2.10", ipv4)
+	assert.Equal(suite.T(), "2001:db8::10", ipv6)
 }
 
 var novaExpectedUp = `


### PR DESCRIPTION
## What changed

Populate `nova_server_status` IP labels from Nova `addresses` when optional `accessIPv4` and `accessIPv6` fields are empty.

## Why

Nova commonly returns assigned addresses only in the standard `addresses` map, leaving the legacy access fields blank.

## Validation

- `go test ./exporters`

Fixes #263.