### PR TITLE
Fail cache collection without exporter data

### DIFF
--- a/cache/utils.go
+++ b/cache/utils.go
@@ -4,6 +4,7 @@ package cache
 
 import (
 	"bytes"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"slices"
@@ -63,6 +64,7 @@ func CollectCache(
 		// Update cloud's cache once finish all exporters' collection job. so we won't mix the old
 		// and new metrics in the cache and confuse users.
 		cloudCache := NewCloudCache()
+		successfulServices := 0
 
 		for _, service := range services {
 			lg2 := lg.With("service", service)
@@ -83,6 +85,7 @@ func CollectCache(
 				lg2.Error("Create gather failed", "error", err)
 				continue
 			}
+			successfulServices++
 
 			for _, mf := range metricFamilies {
 				cloudCache.SetMetricFamilyCache(
@@ -96,6 +99,9 @@ func CollectCache(
 			}
 
 			lg2.Info("Finish update cache data")
+		}
+		if successfulServices == 0 {
+			return fmt.Errorf("failed to collect cache for cloud %q: no exporters produced metrics", cloud)
 		}
 
 		cacheBackend.SetCloudCache(cloud, cloudCache)

--- a/cache/utils_test.go
+++ b/cache/utils_test.go
@@ -2,6 +2,7 @@ package cache
 
 import (
 	"bytes"
+	"errors"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -39,6 +40,26 @@ func mockEnableExporter(
 		gge: prometheus.NewGauge(prometheus.GaugeOpts{Name: "g1", Help: "Help g1"}),
 	}
 	return &exporter, nil
+}
+
+func mockEnableExporterError(
+	service,
+	prefix,
+	cloud string,
+	disabledMetrics []string,
+	endpointType string,
+	collectTime bool,
+	disableSlowMetrics bool,
+	disableDeprecatedMetrics bool,
+	disableCinderAgentUUID bool,
+	domainID string,
+	tenantID string,
+	novaMetadataMapping *utils.LabelMappingFlag,
+	dnsConcurrentCount int,
+	uuidGenFunc func() (string, error),
+	logger *slog.Logger,
+) (*exporters.OpenStackExporter, error) {
+	return nil, errors.New("authentication endpoint is unreachable")
 }
 
 // MockOpenStackExporter is a mock of OpenStackExporter interface
@@ -120,6 +141,35 @@ func TestCollectCache(t *testing.T) {
 
 	assert.Contains(includeServices, "service-a", "service-a should be included in the cache data")
 	assert.NotContains(includeServices, "service-b", "service-b should not be included in the cache data")
+}
+
+func TestCollectCacheFailsWhenNoExporterCanBeEnabled(t *testing.T) {
+	cache := GetCache()
+	defer newSingleCache()
+
+	err := CollectCache(
+		mockEnableExporterError,
+		false,
+		[]string{"service-a"},
+		"testPrefix",
+		"testCloud",
+		nil,
+		"public",
+		false,
+		false,
+		false,
+		false,
+		"",
+		"",
+		new(utils.LabelMappingFlag),
+		10,
+		nil,
+		slog.New(slog.NewTextHandler(os.Stdout, nil)),
+	)
+
+	assert.Error(t, err)
+	_, exists := cache.GetCloudCache("testCloud")
+	assert.False(t, exists)
 }
 
 func TestBufferFromCache(t *testing.T) {


### PR DESCRIPTION
## What changed

Return an error without storing a cloud cache when every configured exporter fails to initialize.

## Why

Previously, failed exporter initialization was logged but an empty cache was stored. The metrics endpoint then responded with HTTP 200 and an empty body.

## Validation

- `go test ./cache`

Fixes #435.