### PR TITLE
Publish Helm charts with exporter releases

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -128,6 +128,22 @@ jobs:
           build-args: |
             GO_VERSION=${{ steps.go-version.outputs.version }}
 
+      - name: Set up Helm
+        if: contains(github.ref, 'refs/tags/')
+        uses: azure/setup-helm@v4
+
+      - name: Publish Helm chart
+        if: contains(github.ref, 'refs/tags/')
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          package_dir="$(mktemp -d)"
+          helm package helmcharts \
+            --destination "$package_dir" \
+            --version "$version" \
+            --app-version "$version"
+          helm push "$package_dir/prometheus-openstack-exporter-$version.tgz" \
+            "oci://ghcr.io/${{ github.repository_owner }}/charts"
+
       # This step runs ONLY when a tag is pushed
       - name: Run GoReleaser (Tag Release)
         if: contains(github.ref, 'refs/tags/')

--- a/helmcharts/README.md
+++ b/helmcharts/README.md
@@ -13,21 +13,22 @@ To use your own Secret instead, set `clouds_yaml_secret_name` to an existing Sec
 
 ## Usage
 
-```bash
-# Package the chart
-cd charts/prometheus-openstack-exporter/
-helm package .
+Helm charts are published to GitHub Container Registry with each OpenStack
+Exporter release. The chart version and application version match the released
+container image tag.
 
-# Get chart version & install
-version="$(awk '/^version:/{ print $NF }' Chart.yaml)"
-helm install prometheus-openstack-exporter prometheus-openstack-exporter-${version}.tgz
+```bash
+# Install a released version (for example, exporter image 1.6.0)
+helm install prometheus-openstack-exporter \
+  oci://ghcr.io/openstack-exporter/charts/prometheus-openstack-exporter \
+  --version 1.6.0
 ```
 
 To render manifests for GitOps workflows such as Argo CD:
 
 ```bash
 # From the repository root
-helm template prometheus-openstack-exporter ./charts/prometheus-openstack-exporter \
+helm template prometheus-openstack-exporter ./helmcharts \
   --namespace openstack \
   --set clouds_yaml_secret_name=my-openstack-config \
   > prometheus-openstack-exporter.yaml


### PR DESCRIPTION
## Summary

- publish the Helm chart to GHCR as an OCI artifact when an exporter release tag is pushed
- derive the packaged chart and application versions from that release tag, matching the container image version
- document OCI installation and correct the local chart path

Closes #598.

## Validation

- `git diff --check`
- parsed `.github/workflows/ci.yaml` with Ruby YAML
- syntax-checked and exercised the chart-publishing shell script with a stub `helm` command
