### PR TITLE
Add flavor specs as metrics with values

### DIFF
--- a/exporters/nova.go
+++ b/exporters/nova.go
@@ -72,6 +72,9 @@ var (
 var defaultNovaMetrics = []Metric{
 	{Name: "flavors", Fn: ListFlavors},
 	{Name: "flavor", Labels: []string{"id", "name", "vcpus", "ram", "disk", "is_public"}},
+	{Name: "flavor_vcpus", Labels: []string{"id", "name", "is_public"}},
+	{Name: "flavor_ram", Labels: []string{"id", "name", "is_public"}},
+	{Name: "flavor_disk", Labels: []string{"id", "name", "is_public"}},
 	{Name: "availability_zones", Fn: ListAZs},
 	{Name: "security_groups", Fn: ListComputeSecGroups},
 	{Name: "total_vms", Fn: ListAllServers},
@@ -271,6 +274,13 @@ func ListFlavors(ctx context.Context, exporter *BaseOpenStackExporter, ch chan<-
 	for _, f := range allFlavors {
 		ch <- prometheus.MustNewConstMetric(exporter.Metrics["flavor"].Metric,
 			prometheus.GaugeValue, 1, f.ID, f.Name, fmt.Sprintf("%v", f.VCPUs), fmt.Sprintf("%v", f.RAM), fmt.Sprintf("%v", f.Disk), fmt.Sprintf("%v", f.IsPublic))
+
+		ch <- prometheus.MustNewConstMetric(exporter.Metrics["flavor_vcpus"].Metric,
+			prometheus.GaugeValue, float64(f.VCPUs), f.ID, f.Name, fmt.Sprintf("%v", f.IsPublic))
+		ch <- prometheus.MustNewConstMetric(exporter.Metrics["flavor_ram"].Metric,
+			prometheus.GaugeValue, float64(f.RAM), f.ID, f.Name, fmt.Sprintf("%v", f.IsPublic))
+		ch <- prometheus.MustNewConstMetric(exporter.Metrics["flavor_disk"].Metric,
+			prometheus.GaugeValue, float64(f.Disk), f.ID, f.Name, fmt.Sprintf("%v", f.IsPublic))
 	}
 
 	return nil

--- a/exporters/nova_test.go
+++ b/exporters/nova_test.go
@@ -34,6 +34,36 @@ openstack_nova_flavor{disk="0",id="5",is_public="true",name="m1.xlarge",ram="163
 openstack_nova_flavor{disk="0",id="6",is_public="true",name="m1.tiny.specs",ram="512",vcpus="1"} 1
 openstack_nova_flavor{disk="0",id="7",is_public="true",name="m1.small.description",ram="2048",vcpus="1"} 1
 openstack_nova_flavor{disk="0",id="8",is_public="false",name="m1.tiny.private",ram="512",vcpus="1"} 1
+# HELP openstack_nova_flavor_vcpus flavor_vcpus
+# TYPE openstack_nova_flavor_vcpus gauge
+openstack_nova_flavor_vcpus{id="1",is_public="true",name="m1.tiny"} 1
+openstack_nova_flavor_vcpus{id="2",is_public="true",name="m1.small"} 1
+openstack_nova_flavor_vcpus{id="3",is_public="true",name="m1.medium"} 2
+openstack_nova_flavor_vcpus{id="4",is_public="true",name="m1.large"} 4
+openstack_nova_flavor_vcpus{id="5",is_public="true",name="m1.xlarge"} 8
+openstack_nova_flavor_vcpus{id="6",is_public="true",name="m1.tiny.specs"} 1
+openstack_nova_flavor_vcpus{id="7",is_public="true",name="m1.small.description"} 1
+openstack_nova_flavor_vcpus{id="8",is_public="false",name="m1.tiny.private"} 1
+# HELP openstack_nova_flavor_ram flavor_ram
+# TYPE openstack_nova_flavor_ram gauge
+openstack_nova_flavor_ram{id="1",is_public="true",name="m1.tiny"} 512
+openstack_nova_flavor_ram{id="2",is_public="true",name="m1.small"} 2048
+openstack_nova_flavor_ram{id="3",is_public="true",name="m1.medium"} 4096
+openstack_nova_flavor_ram{id="4",is_public="true",name="m1.large"} 8192
+openstack_nova_flavor_ram{id="5",is_public="true",name="m1.xlarge"} 16384
+openstack_nova_flavor_ram{id="6",is_public="true",name="m1.tiny.specs"} 512
+openstack_nova_flavor_ram{id="7",is_public="true",name="m1.small.description"} 2048
+openstack_nova_flavor_ram{id="8",is_public="false",name="m1.tiny.private"} 512
+# HELP openstack_nova_flavor_disk flavor_disk
+# TYPE openstack_nova_flavor_disk gauge
+openstack_nova_flavor_disk{id="1",is_public="true",name="m1.tiny"} 0
+openstack_nova_flavor_disk{id="2",is_public="true",name="m1.small"} 0
+openstack_nova_flavor_disk{id="3",is_public="true",name="m1.medium"} 0
+openstack_nova_flavor_disk{id="4",is_public="true",name="m1.large"} 0
+openstack_nova_flavor_disk{id="5",is_public="true",name="m1.xlarge"} 0
+openstack_nova_flavor_disk{id="6",is_public="true",name="m1.tiny.specs"} 0
+openstack_nova_flavor_disk{id="7",is_public="true",name="m1.small.description"} 0
+openstack_nova_flavor_disk{id="8",is_public="false",name="m1.tiny.private"} 0
 # HELP openstack_nova_flavors flavors
 # TYPE openstack_nova_flavors gauge
 openstack_nova_flavors 8


### PR DESCRIPTION
## What changed

Export openstack_nova_flavor_{vcpus,ram,disk}

## Why

Nova flavor specs are currently exported as label values, so you can't use them in calculations. This makes them separate metrics with values.

## Validation

- `go test ./exporters`
