### PR TITLE
Allow adding extra volumes to openstack-exporter helm chart deployment

### DIFF
--- a/helmcharts/templates/deployment.yaml
+++ b/helmcharts/templates/deployment.yaml
@@ -34,6 +34,9 @@ spec:
         volumeMounts:
           - name: openstack-config
             mountPath: /etc/openstack
+        {{- if .Values.extraVolumeMounts }}
+          {{- toYaml .Values.extraVolumeMounts | nindent 10 }}
+        {{- end }}
         ports:
         - name: metrics
           containerPort: 9180
@@ -46,6 +49,9 @@ spec:
       - name: openstack-config
         secret:
           secretName: {{ include "openstack-exporter.cloudsYamlSecretName" . }}
+      {{- if .Values.extraVolumes }}
+        {{- toYaml .Values.extraVolumes | nindent 6 }}
+      {{- end }}
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
 {{ toYaml . | indent 8 }}

--- a/helmcharts/values.yaml
+++ b/helmcharts/values.yaml
@@ -55,6 +55,21 @@ multicloud:
 #commonLabels:
 #  prometheus.io/monitor: "true"
 
+# Add extra volumes mounted to openstack-exporter deployment
+# Useful for mounting CA Certificates
+#extraVolumes:
+#- name: company-ca
+#  configMap:
+#    name: my-company-ca
+#    items:
+#    - key: ca
+#      path: my-company-ca
+#
+#extraVolumeMounts:
+#- mountPath: /etc/ssl/certs/my-company-ca
+#  name: company-ca
+#  subPath: my-company-ca
+
 # Generate a secret for clouds.yaml
 # Doc: https://github.com/openstack-exporter/openstack-exporter#openstack-configuration
 # Set clouds_yaml_secret_name to use an existing Secret instead. The Secret must contain a clouds.yaml key.


### PR DESCRIPTION
This small change in helm chart allows consumers to mount arbitrary volumes into openstack-exporter Deployment.

Here are example values to mount CA certificate of someone's company as ConfigMap into the Deployment.

```yaml
extraVolumes:
- name: company-ca
  configMap:
    name: my-company-ca
    items:
    - key: ca
      path: my-company-ca

extraVolumeMounts:
- mountPath: /etc/ssl/certs/my-company-ca
  name: company-ca
  subPath: my-company-ca
```

ConfigMap can look like this:

```yaml
kind: ConfigMap
apiVersion: v1
metadata:
  name: my-company-ca
data:
  ca: |
    -----BEGIN CERTIFICATE-----
    ....
    -----END CERTIFICATE-----
```

This CaCert can be then used within cloud config `cloud.yaml`:

```yaml
clouds:
  default:
    region_name: RegionZero
    auth:
      username: "user"
      password: "pass"
      project_name: "my-project"
      project_domain_name: "project-domain"
      user_domain_name: "user-domain"
      auth_url: "https://keystone.example.com:5000"
    verify: true
    cacert: /etc/ssl/certs/my-company-ca
```

Original [PR in helm chart repo](https://github.com/openstack-exporter/helm-charts/pull/11) by Ondrej Vasko <o.vasko@pan-net.eu> 